### PR TITLE
feat: #1 프로젝트 초기 설정 - Payment Service 보일러플레이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac ###
+.DS_Store
+
+### Env ###
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:8.12-jdk21 AS build
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon || true
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+EXPOSE 8085
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,60 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.10'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.opentraum'
+version = '0.0.1-SNAPSHOT'
+description = 'OpenTraum Payment Service'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', '2025.0.0')
+}
+
+dependencies {
+    // Spring Boot Starters
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Monitoring
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // R2DBC PostgreSQL
+    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+    runtimeOnly 'org.postgresql:postgresql'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opentraum-payment-service'

--- a/src/main/java/com/opentraum/payment/PaymentServiceApplication.java
+++ b/src/main/java/com/opentraum/payment/PaymentServiceApplication.java
@@ -1,0 +1,12 @@
+package com.opentraum.payment;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/opentraum/payment/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/payment/config/KafkaConfig.java
@@ -1,0 +1,9 @@
+package com.opentraum.payment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+}

--- a/src/main/java/com/opentraum/payment/config/R2dbcConfig.java
+++ b/src/main/java/com/opentraum/payment/config/R2dbcConfig.java
@@ -1,0 +1,11 @@
+package com.opentraum.payment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+@Configuration
+@EnableR2dbcRepositories(basePackages = "com.opentraum.payment.domain.repository")
+@EnableR2dbcAuditing
+public class R2dbcConfig {
+}

--- a/src/main/java/com/opentraum/payment/domain/controller/PaymentController.java
+++ b/src/main/java/com/opentraum/payment/domain/controller/PaymentController.java
@@ -1,0 +1,48 @@
+package com.opentraum.payment.domain.controller;
+
+import com.opentraum.payment.domain.dto.PaymentRequest;
+import com.opentraum.payment.domain.dto.PaymentResponse;
+import com.opentraum.payment.domain.dto.RefundRequest;
+import com.opentraum.payment.domain.service.PaymentService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    public PaymentController(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<PaymentResponse> processPayment(@Valid @RequestBody PaymentRequest request) {
+        return paymentService.processPayment(request);
+    }
+
+    @GetMapping("/{id}")
+    public Mono<PaymentResponse> getPayment(@PathVariable Long id) {
+        return paymentService.getPaymentById(id);
+    }
+
+    @GetMapping("/reservation/{reservationId}")
+    public Mono<PaymentResponse> getPaymentByReservation(@PathVariable Long reservationId) {
+        return paymentService.getPaymentByReservationId(reservationId);
+    }
+
+    @GetMapping("/user/{userId}")
+    public Flux<PaymentResponse> getPaymentsByUser(@PathVariable Long userId) {
+        return paymentService.getPaymentsByUserId(userId);
+    }
+
+    @PostMapping("/refund")
+    public Mono<PaymentResponse> refund(@Valid @RequestBody RefundRequest request) {
+        return paymentService.refund(request);
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/PaymentRequest.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/PaymentRequest.java
@@ -1,0 +1,22 @@
+package com.opentraum.payment.domain.dto;
+
+import com.opentraum.payment.domain.entity.Payment;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record PaymentRequest(
+        @NotNull Long reservationId,
+        @NotNull Long userId,
+        @NotNull Long tenantId,
+        @NotNull @Positive BigDecimal amount,
+        String currency,
+        @NotNull Payment.PaymentMethod method
+) {
+    public PaymentRequest {
+        if (currency == null || currency.isBlank()) {
+            currency = "KRW";
+        }
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/PaymentResponse.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/PaymentResponse.java
@@ -1,0 +1,36 @@
+package com.opentraum.payment.domain.dto;
+
+import com.opentraum.payment.domain.entity.Payment;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PaymentResponse(
+        Long id,
+        Long reservationId,
+        Long userId,
+        Long tenantId,
+        BigDecimal amount,
+        String currency,
+        Payment.PaymentMethod method,
+        Payment.PaymentStatus status,
+        String pgTransactionId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getReservationId(),
+                payment.getUserId(),
+                payment.getTenantId(),
+                payment.getAmount(),
+                payment.getCurrency(),
+                payment.getMethod(),
+                payment.getStatus(),
+                payment.getPgTransactionId(),
+                payment.getCreatedAt(),
+                payment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/RefundRequest.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/RefundRequest.java
@@ -1,0 +1,13 @@
+package com.opentraum.payment.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record RefundRequest(
+        @NotNull Long paymentId,
+        @NotNull @Positive BigDecimal amount,
+        String reason
+) {
+}

--- a/src/main/java/com/opentraum/payment/domain/entity/Payment.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/Payment.java
@@ -1,0 +1,77 @@
+package com.opentraum.payment.domain.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.core.mapping.Column;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Table("payments")
+public class Payment {
+
+    @Id
+    private Long id;
+
+    @Column("reservation_id")
+    private Long reservationId;
+
+    @Column("user_id")
+    private Long userId;
+
+    @Column("tenant_id")
+    private Long tenantId;
+
+    private BigDecimal amount;
+
+    private String currency;
+
+    private PaymentMethod method;
+
+    private PaymentStatus status;
+
+    @Column("pg_transaction_id")
+    private String pgTransactionId;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum PaymentMethod {
+        CARD, TRANSFER, KAKAO_PAY
+    }
+
+    public enum PaymentStatus {
+        PENDING, COMPLETED, FAILED, REFUNDED
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getReservationId() { return reservationId; }
+    public void setReservationId(Long reservationId) { this.reservationId = reservationId; }
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public Long getTenantId() { return tenantId; }
+    public void setTenantId(Long tenantId) { this.tenantId = tenantId; }
+    public BigDecimal getAmount() { return amount; }
+    public void setAmount(BigDecimal amount) { this.amount = amount; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public PaymentMethod getMethod() { return method; }
+    public void setMethod(PaymentMethod method) { this.method = method; }
+    public PaymentStatus getStatus() { return status; }
+    public void setStatus(PaymentStatus status) { this.status = status; }
+    public String getPgTransactionId() { return pgTransactionId; }
+    public void setPgTransactionId(String pgTransactionId) { this.pgTransactionId = pgTransactionId; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/opentraum/payment/domain/entity/Refund.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/Refund.java
@@ -1,0 +1,47 @@
+package com.opentraum.payment.domain.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.core.mapping.Column;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Table("refunds")
+public class Refund {
+
+    @Id
+    private Long id;
+
+    @Column("payment_id")
+    private Long paymentId;
+
+    private BigDecimal amount;
+
+    private String reason;
+
+    private RefundStatus status;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    public enum RefundStatus {
+        PENDING, COMPLETED, REJECTED
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getPaymentId() { return paymentId; }
+    public void setPaymentId(Long paymentId) { this.paymentId = paymentId; }
+    public BigDecimal getAmount() { return amount; }
+    public void setAmount(BigDecimal amount) { this.amount = amount; }
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+    public RefundStatus getStatus() { return status; }
+    public void setStatus(RefundStatus status) { this.status = status; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/opentraum/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/opentraum/payment/domain/repository/PaymentRepository.java
@@ -1,0 +1,17 @@
+package com.opentraum.payment.domain.repository;
+
+import com.opentraum.payment.domain.entity.Payment;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface PaymentRepository extends R2dbcRepository<Payment, Long> {
+
+    Mono<Payment> findByReservationId(Long reservationId);
+
+    Flux<Payment> findByUserId(Long userId);
+
+    Flux<Payment> findByTenantId(Long tenantId);
+
+    Flux<Payment> findByStatus(Payment.PaymentStatus status);
+}

--- a/src/main/java/com/opentraum/payment/domain/repository/RefundRepository.java
+++ b/src/main/java/com/opentraum/payment/domain/repository/RefundRepository.java
@@ -1,0 +1,10 @@
+package com.opentraum.payment.domain.repository;
+
+import com.opentraum.payment.domain.entity.Refund;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+
+public interface RefundRepository extends R2dbcRepository<Refund, Long> {
+
+    Flux<Refund> findByPaymentId(Long paymentId);
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
@@ -1,0 +1,20 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.dto.PaymentRequest;
+import com.opentraum.payment.domain.dto.PaymentResponse;
+import com.opentraum.payment.domain.dto.RefundRequest;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface PaymentService {
+
+    Mono<PaymentResponse> processPayment(PaymentRequest request);
+
+    Mono<PaymentResponse> getPaymentById(Long id);
+
+    Mono<PaymentResponse> getPaymentByReservationId(Long reservationId);
+
+    Flux<PaymentResponse> getPaymentsByUserId(Long userId);
+
+    Mono<PaymentResponse> refund(RefundRequest request);
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentServiceImpl.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentServiceImpl.java
@@ -1,0 +1,82 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.dto.PaymentRequest;
+import com.opentraum.payment.domain.dto.PaymentResponse;
+import com.opentraum.payment.domain.dto.RefundRequest;
+import com.opentraum.payment.domain.entity.Payment;
+import com.opentraum.payment.domain.entity.Refund;
+import com.opentraum.payment.domain.repository.PaymentRepository;
+import com.opentraum.payment.domain.repository.RefundRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@Transactional
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final RefundRepository refundRepository;
+
+    public PaymentServiceImpl(PaymentRepository paymentRepository, RefundRepository refundRepository) {
+        this.paymentRepository = paymentRepository;
+        this.refundRepository = refundRepository;
+    }
+
+    @Override
+    public Mono<PaymentResponse> processPayment(PaymentRequest request) {
+        Payment payment = new Payment();
+        payment.setReservationId(request.reservationId());
+        payment.setUserId(request.userId());
+        payment.setTenantId(request.tenantId());
+        payment.setAmount(request.amount());
+        payment.setCurrency(request.currency());
+        payment.setMethod(request.method());
+        payment.setStatus(Payment.PaymentStatus.PENDING);
+
+        return paymentRepository.save(payment)
+                .map(PaymentResponse::from);
+        // TODO: PG 연동 및 Kafka 이벤트 발행
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Mono<PaymentResponse> getPaymentById(Long id) {
+        return paymentRepository.findById(id)
+                .map(PaymentResponse::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Mono<PaymentResponse> getPaymentByReservationId(Long reservationId) {
+        return paymentRepository.findByReservationId(reservationId)
+                .map(PaymentResponse::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Flux<PaymentResponse> getPaymentsByUserId(Long userId) {
+        return paymentRepository.findByUserId(userId)
+                .map(PaymentResponse::from);
+    }
+
+    @Override
+    public Mono<PaymentResponse> refund(RefundRequest request) {
+        return paymentRepository.findById(request.paymentId())
+                .flatMap(payment -> {
+                    Refund refund = new Refund();
+                    refund.setPaymentId(payment.getId());
+                    refund.setAmount(request.amount());
+                    refund.setReason(request.reason());
+                    refund.setStatus(Refund.RefundStatus.PENDING);
+
+                    payment.setStatus(Payment.PaymentStatus.REFUNDED);
+
+                    return refundRepository.save(refund)
+                            .then(paymentRepository.save(payment))
+                            .map(PaymentResponse::from);
+                    // TODO: PG 환불 연동 및 Kafka 이벤트 발행
+                });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,55 @@
+server:
+  port: 8085
+
+spring:
+  application:
+    name: opentraum-payment-service
+
+  r2dbc:
+    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+    username: ${DB_USERNAME:opentraum}
+    password: ${DB_PASSWORD:opentraum}
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: payment-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  r2dbc:
+    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/opentraum_payment

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS payments (
+    id BIGSERIAL PRIMARY KEY,
+    reservation_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    tenant_id BIGINT NOT NULL,
+    amount DECIMAL(12, 2) NOT NULL,
+    currency VARCHAR(3) NOT NULL DEFAULT 'KRW',
+    method VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    pg_transaction_id VARCHAR(100),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS refunds (
+    id BIGSERIAL PRIMARY KEY,
+    payment_id BIGINT NOT NULL REFERENCES payments(id),
+    amount DECIMAL(12, 2) NOT NULL,
+    reason VARCHAR(500),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_payments_reservation_id ON payments(reservation_id);
+CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);
+CREATE INDEX IF NOT EXISTS idx_payments_tenant_id ON payments(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_refunds_payment_id ON refunds(payment_id);


### PR DESCRIPTION
## 개요
OpenTraum 결제 서비스(Payment Service)의 보일러플레이트를 구축합니다.

결제 서비스는 예매 확정 후 실제 결제를 처리하고, 결제 상태 조회 및 환불 기능을 담당합니다.
Kafka를 통해 reservation-service와 이벤트 기반 비동기 통신을 수행합니다.

Closes #1

## 변경사항

### 프로젝트 설정
- Spring Boot 3.5.10 + WebFlux (Reactive) 기반 프로젝트 초기화
- Java 21, Gradle 8.12 (Groovy DSL)
- R2DBC PostgreSQL, Kafka, Actuator + Prometheus 의존성 구성

### 도메인 계층
- **Entity**: `Payment` (결제 정보 - 금액, 수단, 상태, PG 트랜잭션 ID 등), `Refund` (환불 정보)
- **Repository**: `PaymentRepository`, `RefundRepository` (R2DBC Reactive Repository)
- **DTO**: `PaymentRequest`, `PaymentResponse`, `RefundRequest` (Java Record)
- **Service**: `PaymentService` 인터페이스 + `PaymentServiceImpl` 구현체
- **Controller**: `PaymentController` - 결제 처리, 조회, 환불 REST API

### API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/v1/payments` | 결제 처리 |
| GET | `/api/v1/payments/{id}` | 결제 상세 조회 |
| GET | `/api/v1/payments/reservation/{reservationId}` | 예매별 결제 조회 |
| GET | `/api/v1/payments/user/{userId}` | 사용자별 결제 목록 |
| POST | `/api/v1/payments/refund` | 환불 처리 |

### 결제 상태 흐름
```
PENDING → COMPLETED (결제 성공)
PENDING → FAILED (결제 실패)
COMPLETED → REFUNDED (환불 처리)
```

### 인프라
- `Dockerfile` 멀티 스테이지 빌드 (Gradle → JRE 21 Alpine)
- `application.yml` 프로필별 설정 (default, dev, prod)
- `schema.sql` DDL (payments, refunds 테이블 + 인덱스)

### 서비스 포트: **8085**

## 테스트 계획
- [ ] 프로젝트 빌드 정상 확인 (`./gradlew build`)
- [ ] 애플리케이션 기동 확인 (PostgreSQL, Kafka 연결 상태)
- [ ] Actuator health endpoint 응답 확인
- [ ] 결제 API CRUD 동작 확인
- [ ] 환불 처리 플로우 확인