### PR TITLE
feat: #3 FairTicket 코드 마이그레이션 - Payment 도메인

### DIFF
--- a/src/main/java/com/opentraum/payment/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/payment/config/KafkaConfig.java
@@ -1,9 +1,61 @@
 package com.opentraum.payment.config;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableKafka
 public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    // Producer
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Consumer
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
 }

--- a/src/main/java/com/opentraum/payment/config/KafkaTopics.java
+++ b/src/main/java/com/opentraum/payment/config/KafkaTopics.java
@@ -1,0 +1,10 @@
+package com.opentraum.payment.config;
+
+public class KafkaTopics {
+
+    private KafkaTopics() {}
+
+    public static final String SEAT_ASSIGNMENT     = "seat-assignment";
+    public static final String SEAT_ASSIGNMENT_DLQ = "seat-assignment-dlq";
+    public static final String REFUND              = "refund";
+}

--- a/src/main/java/com/opentraum/payment/config/RedisConfig.java
+++ b/src/main/java/com/opentraum/payment/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.opentraum.payment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Primary
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
+            ReactiveRedisConnectionFactory connectionFactory) {
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+
+        RedisSerializationContext<String, String> context = RedisSerializationContext
+                .<String, String>newSerializationContext(serializer)
+                .key(serializer)
+                .value(serializer)
+                .hashKey(serializer)
+                .hashValue(serializer)
+                .build();
+
+        return new ReactiveRedisTemplate<>(connectionFactory, context);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+}

--- a/src/main/java/com/opentraum/payment/config/SwaggerConfig.java
+++ b/src/main/java/com/opentraum/payment/config/SwaggerConfig.java
@@ -1,0 +1,44 @@
+package com.opentraum.payment.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openTraumPaymentOpenAPI() {
+        String securitySchemeName = "Bearer Token";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("OpenTraum Payment Service API")
+                        .description("멀티 테넌시 티켓팅 결제 서비스 API 문서")
+                        .version("v1.0.0")
+                        .contact(new Contact()
+                                .name("OpenTraum Team")
+                                .email("support@opentraum.com")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8085")
+                                .description("로컬 개발 서버")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/constants/PaymentConstants.java
+++ b/src/main/java/com/opentraum/payment/domain/constants/PaymentConstants.java
@@ -1,0 +1,14 @@
+package com.opentraum.payment.domain.constants;
+
+/**
+ * 결제 관련 공통 상수
+ */
+public final class PaymentConstants {
+
+    private PaymentConstants() {
+        throw new UnsupportedOperationException("상수 클래스는 인스턴스화할 수 없습니다.");
+    }
+
+    // 결제 유효 시간 (분). 미결제 시 자동 취소
+    public static final int PAYMENT_DEADLINE_MINUTES = 5;
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/PaymentCompleteRequest.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/PaymentCompleteRequest.java
@@ -1,0 +1,11 @@
+package com.opentraum.payment.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PaymentCompleteRequest {
+    private String impUid;      // PortOne 결제 고유번호
+    private String merchantUid; // 우리 시스템 주문번호
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/PaymentInitResponse.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/PaymentInitResponse.java
@@ -1,0 +1,14 @@
+package com.opentraum.payment.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentInitResponse {
+    private String merchantUid;
+    private Integer amount;
+    private String itemName;
+    private Long paymentId;
+    private Integer timeoutSeconds; // 결제 제한 시간
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/PaymentTimerResponse.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/PaymentTimerResponse.java
@@ -1,0 +1,13 @@
+package com.opentraum.payment.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentTimerResponse {
+
+    private Long reservationId;
+    private Long remainingSeconds;
+    private boolean expired;
+}

--- a/src/main/java/com/opentraum/payment/domain/dto/WebhookRequest.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/WebhookRequest.java
@@ -1,0 +1,15 @@
+package com.opentraum.payment.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebhookRequest {
+    @JsonProperty("imp_uid")
+    private String impUid;       // PortOne 결제 고유번호
+
+    @JsonProperty("merchant_uid")
+    private String merchantUid;  // 우리 시스템 주문번호
+}

--- a/src/main/java/com/opentraum/payment/domain/entity/Payment.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/Payment.java
@@ -1,77 +1,43 @@
 package com.opentraum.payment.domain.entity;
 
+import lombok.*;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.relational.core.mapping.Table;
-import org.springframework.data.relational.core.mapping.Column;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Table("payments")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Payment {
 
     @Id
     private Long id;
 
-    @Column("reservation_id")
     private Long reservationId;
 
-    @Column("user_id")
-    private Long userId;
+    private String merchantUid;
 
-    @Column("tenant_id")
+    private String impUid;
+
+    private String pgTid;
+
+    private Integer amount;
+
+    private String method;
+
+    private String status;
+
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime paidAt;
+
     private Long tenantId;
 
-    private BigDecimal amount;
-
-    private String currency;
-
-    private PaymentMethod method;
-
-    private PaymentStatus status;
-
-    @Column("pg_transaction_id")
-    private String pgTransactionId;
-
-    @CreatedDate
-    @Column("created_at")
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column("updated_at")
     private LocalDateTime updatedAt;
-
-    public enum PaymentMethod {
-        CARD, TRANSFER, KAKAO_PAY
-    }
-
-    public enum PaymentStatus {
-        PENDING, COMPLETED, FAILED, REFUNDED
-    }
-
-    // Getters and Setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
-    public Long getReservationId() { return reservationId; }
-    public void setReservationId(Long reservationId) { this.reservationId = reservationId; }
-    public Long getUserId() { return userId; }
-    public void setUserId(Long userId) { this.userId = userId; }
-    public Long getTenantId() { return tenantId; }
-    public void setTenantId(Long tenantId) { this.tenantId = tenantId; }
-    public BigDecimal getAmount() { return amount; }
-    public void setAmount(BigDecimal amount) { this.amount = amount; }
-    public String getCurrency() { return currency; }
-    public void setCurrency(String currency) { this.currency = currency; }
-    public PaymentMethod getMethod() { return method; }
-    public void setMethod(PaymentMethod method) { this.method = method; }
-    public PaymentStatus getStatus() { return status; }
-    public void setStatus(PaymentStatus status) { this.status = status; }
-    public String getPgTransactionId() { return pgTransactionId; }
-    public void setPgTransactionId(String pgTransactionId) { this.pgTransactionId = pgTransactionId; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
 }

--- a/src/main/java/com/opentraum/payment/domain/entity/PaymentStatus.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.opentraum.payment.domain.entity;
+
+public enum PaymentStatus {
+    PENDING,      // 결제 대기
+    COMPLETED,    // 결제 완료
+    FAILED,       // PG 결제 실패 (카드 한도, 인증 실패)
+    CANCELLED,    // 타임아웃으로 자동 취소
+    REFUNDED      // 환불 완료
+}

--- a/src/main/java/com/opentraum/payment/domain/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/opentraum/payment/domain/repository/PaymentQueryRepository.java
@@ -1,0 +1,45 @@
+package com.opentraum.payment.domain.repository;
+
+import com.opentraum.payment.domain.entity.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+import java.time.LocalDateTime;
+
+/**
+ * R2DBC는 JOIN을 자동 지원하지 않으므로 DatabaseClient로 직접 쿼리
+ * Payment -> Reservation (1:1) -> User
+ */
+@Repository
+@RequiredArgsConstructor
+public class PaymentQueryRepository {
+
+    private final DatabaseClient databaseClient;
+
+    // userId 기준 결제 목록 조회 (Payment JOIN Reservation)
+    public Flux<Payment> findByUserId(Long userId) {
+        return databaseClient.sql("""
+                SELECT p.*
+                FROM payments p
+                JOIN reservations r ON p.reservation_id = r.id
+                WHERE r.user_id = :userId
+                ORDER BY p.created_at DESC
+                """)
+                .bind("userId", userId)
+                .map((row, metadata) -> Payment.builder()
+                        .id(row.get("id", Long.class))
+                        .reservationId(row.get("reservation_id", Long.class))
+                        .merchantUid(row.get("merchant_uid", String.class))
+                        .impUid(row.get("imp_uid", String.class))
+                        .amount(row.get("amount", Integer.class))
+                        .status(row.get("status", String.class))
+                        .tenantId(row.get("tenant_id", Long.class))
+                        .paidAt(row.get("paid_at", LocalDateTime.class))
+                        .createdAt(row.get("created_at", LocalDateTime.class))
+                        .updatedAt(row.get("updated_at", LocalDateTime.class))
+                        .build())
+                .all();
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/opentraum/payment/domain/repository/PaymentRepository.java
@@ -1,17 +1,19 @@
 package com.opentraum.payment.domain.repository;
 
 import com.opentraum.payment.domain.entity.Payment;
-import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface PaymentRepository extends R2dbcRepository<Payment, Long> {
+public interface PaymentRepository extends ReactiveCrudRepository<Payment, Long> {
+
+    Mono<Payment> findByMerchantUid(String merchantUid);
 
     Mono<Payment> findByReservationId(Long reservationId);
 
-    Flux<Payment> findByUserId(Long userId);
+    Mono<Payment> findByImpUid(String impUid);
 
-    Flux<Payment> findByTenantId(Long tenantId);
+    Flux<Payment> findByReservationIdAndStatus(Long reservationId, String status);
 
-    Flux<Payment> findByStatus(Payment.PaymentStatus status);
+    Flux<Payment> findByStatus(String status);
 }

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentEventProducer.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentEventProducer.java
@@ -1,0 +1,57 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.config.KafkaTopics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentEventProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    // 결제 완료 이벤트 발행 -> seat-assignment 토픽
+    // key: reservationId (같은 예약의 이벤트 순서 보장)
+    public Mono<Void> sendSeatAssignmentEvent(Long reservationId, Long userId,
+                                               Long scheduleId, String grade) {
+        String message = String.format(
+                "{\"reservationId\":%d,\"userId\":%d,\"scheduleId\":%d,\"grade\":\"%s\"}",
+                reservationId, userId, scheduleId, grade
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.SEAT_ASSIGNMENT,
+                        String.valueOf(reservationId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] seat-assignment 발행: reservationId={}, grade={}",
+                        reservationId, grade))
+                .doOnError(e -> log.error("[Kafka] seat-assignment 발행 실패: reservationId={}, error={}",
+                        reservationId, e.getMessage()))
+                .then();
+    }
+
+    // 환불 이벤트 발행 -> refund 토픽
+    public Mono<Void> sendRefundEvent(Long paymentId, Long reservationId, int amount, String reason) {
+        String message = String.format(
+                "{\"paymentId\":%d,\"reservationId\":%d,\"amount\":%d,\"reason\":\"%s\"}",
+                paymentId, reservationId, amount, reason
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.REFUND,
+                        String.valueOf(paymentId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] refund 발행: paymentId={}, amount={}",
+                        paymentId, amount))
+                .doOnError(e -> log.error("[Kafka] refund 발행 실패: paymentId={}, error={}",
+                        paymentId, e.getMessage()))
+                .then();
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentExpiryScheduler.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentExpiryScheduler.java
@@ -1,0 +1,57 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.constants.PaymentConstants;
+import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.domain.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 결제 준비(prepare) 후 결제창 미진입(impUid=null)으로 5분 경과한 Payment를 CANCELLED 처리.
+ * PaymentVerificationScheduler는 impUid가 있는 결제만 PortOne 검증하므로,
+ * impUid=null인 결제는 이 스케줄러가 정리한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiryScheduler {
+
+    private final PaymentRepository paymentRepository;
+
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    public void cancelExpiredUnpaidPayments() {
+        try {
+            LocalDateTime threshold = LocalDateTime.now()
+                    .minusMinutes(PaymentConstants.PAYMENT_DEADLINE_MINUTES);
+
+            paymentRepository.findByStatus(PaymentStatus.PENDING.name())
+                    .filter(payment -> payment.getCreatedAt() != null
+                            && payment.getCreatedAt().isBefore(threshold))
+                    .filter(payment -> payment.getImpUid() == null)
+                    .flatMap(payment -> {
+                        payment.setStatus(PaymentStatus.CANCELLED.name());
+                        payment.setUpdatedAt(LocalDateTime.now());
+                        return paymentRepository.save(payment)
+                                .doOnSuccess(v -> log.info("미결제 자동 취소: paymentId={}, reservationId={}",
+                                        payment.getId(), payment.getReservationId()))
+                                .thenReturn(payment);
+                    })
+                    .count()
+                    .doOnSuccess(count -> {
+                        if (count > 0) {
+                            log.info("미결제 만료 처리: {}건", count);
+                        }
+                    })
+                    .block(Duration.ofSeconds(30));
+
+        } catch (Exception e) {
+            log.error("미결제 만료 스케줄러 오류", e);
+        }
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
@@ -1,20 +1,128 @@
 package com.opentraum.payment.domain.service;
 
-import com.opentraum.payment.domain.dto.PaymentRequest;
-import com.opentraum.payment.domain.dto.PaymentResponse;
-import com.opentraum.payment.domain.dto.RefundRequest;
+import com.opentraum.payment.domain.constants.PaymentConstants;
+import com.opentraum.payment.domain.dto.PaymentInitResponse;
+import com.opentraum.payment.domain.dto.WebhookRequest;
+import com.opentraum.payment.domain.entity.Payment;
+import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.domain.repository.PaymentRepository;
+import com.opentraum.payment.domain.repository.PaymentQueryRepository;
+import com.opentraum.payment.global.exception.BusinessException;
+import com.opentraum.payment.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface PaymentService {
+import java.time.LocalDateTime;
+import java.util.UUID;
 
-    Mono<PaymentResponse> processPayment(PaymentRequest request);
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
 
-    Mono<PaymentResponse> getPaymentById(Long id);
+    private final PaymentRepository paymentRepository;
+    private final PaymentQueryRepository paymentQueryRepository;
+    private final PortOneClient portOneClient;
+    private final PaymentTimerService timerService;
 
-    Mono<PaymentResponse> getPaymentByReservationId(Long reservationId);
+    // 결제 준비 (결제창 호출 전)
+    public Mono<PaymentInitResponse> initiatePayment(Long reservationId, Integer amount,
+                                                      String itemName, Long tenantId) {
+        String merchantUid = generateMerchantUid();
 
-    Flux<PaymentResponse> getPaymentsByUserId(Long userId);
+        Payment payment = Payment.builder()
+                .reservationId(reservationId)
+                .merchantUid(merchantUid)
+                .amount(amount)
+                .tenantId(tenantId)
+                .status(PaymentStatus.PENDING.name())
+                .createdAt(LocalDateTime.now())
+                .build();
 
-    Mono<PaymentResponse> refund(RefundRequest request);
+        return paymentRepository.save(payment)
+                .flatMap(saved -> timerService.startPaymentTimer(reservationId)
+                        .thenReturn(saved))
+                .map(saved -> PaymentInitResponse.builder()
+                        .paymentId(saved.getId())
+                        .merchantUid(saved.getMerchantUid())
+                        .amount(saved.getAmount())
+                        .itemName(itemName)
+                        .timeoutSeconds(PaymentConstants.PAYMENT_DEADLINE_MINUTES * 60)
+                        .build());
+    }
+
+    // 결제 완료 처리 - PortOne Webhook 수신
+    public Mono<Payment> completePayment(WebhookRequest request) {
+        return paymentRepository.findByMerchantUid(request.getMerchantUid())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
+                // 1. 이미 완료된 결제 중복 처리 방지
+                .flatMap(payment -> {
+                    if (PaymentStatus.COMPLETED.name().equals(payment.getStatus())) {
+                        return Mono.error(new BusinessException(ErrorCode.PAYMENT_ALREADY_COMPLETED));
+                    }
+                    return Mono.just(payment);
+                })
+                // 2. PG사 금액 검증 (V2: merchantUid = PortOne paymentId)
+                .flatMap(payment -> portOneClient.verifyPayment(request.getMerchantUid())
+                        .flatMap(verification -> {
+                            if (!payment.getAmount().equals(verification.getAmount())) {
+                                log.error("결제 금액 불일치: expected={}, actual={}",
+                                        payment.getAmount(), verification.getAmount());
+                                return Mono.error(new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
+                            }
+                            payment.setImpUid(request.getImpUid());
+                            payment.setStatus(PaymentStatus.COMPLETED.name());
+                            payment.setPaidAt(LocalDateTime.now());
+                            payment.setUpdatedAt(LocalDateTime.now());
+                            return paymentRepository.save(payment);
+                        }))
+                // 3. 타이머 취소
+                .flatMap(payment -> timerService.cancelPaymentTimer(payment.getReservationId())
+                        .thenReturn(payment))
+                .doOnSuccess(payment -> log.info("결제 완료: paymentId={}, merchantUid={}",
+                        payment.getId(), payment.getMerchantUid()));
+    }
+
+    // 환불 처리
+    public Mono<PortOneClient.RefundResult> refundPayment(Long paymentId, String reason) {
+        return paymentRepository.findById(paymentId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
+                .flatMap(payment -> portOneClient.cancelPayment(
+                        payment.getMerchantUid(),
+                        payment.getAmount(),
+                        reason
+                ).flatMap(result -> {
+                    if (result.isSuccess()) {
+                        payment.setStatus(PaymentStatus.REFUNDED.name());
+                        payment.setUpdatedAt(LocalDateTime.now());
+                        return paymentRepository.save(payment).thenReturn(result);
+                    }
+                    return Mono.just(result);
+                }));
+    }
+
+    // 결제 단건 조회
+    public Mono<Payment> getPayment(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)));
+    }
+
+    // 예약 기준 결제 조회
+    public Mono<Payment> getPaymentByReservationId(Long reservationId) {
+        return paymentRepository.findByReservationId(reservationId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)));
+    }
+
+    // 내 결제 목록 조회
+    public Flux<Payment> getMyPayments(Long userId) {
+        return paymentQueryRepository.findByUserId(userId);
+    }
+
+    private String generateMerchantUid() {
+        return "OT_" + System.currentTimeMillis() + "_" +
+                UUID.randomUUID().toString().substring(0, 8);
+    }
 }

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentTimerService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentTimerService.java
@@ -1,0 +1,62 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.constants.PaymentConstants;
+import com.opentraum.payment.global.exception.BusinessException;
+import com.opentraum.payment.global.exception.ErrorCode;
+import com.opentraum.payment.global.util.RedisKeyGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class PaymentTimerService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    public PaymentTimerService(
+            @Qualifier("reactiveRedisTemplate") ReactiveRedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 결제 타이머 시작 (공통 5분)
+    public Mono<Void> startPaymentTimer(Long reservationId) {
+        String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
+        Duration ttl = Duration.ofMinutes(PaymentConstants.PAYMENT_DEADLINE_MINUTES);
+
+        return redisTemplate.opsForValue()
+                .set(timerKey, "PENDING", ttl)
+                .doOnSuccess(v -> log.info("결제 타이머 시작: reservationId={}, ttl={}분",
+                        reservationId, ttl.toMinutes()))
+                .then();
+    }
+
+    // 결제 타이머 취소 (결제 완료 시)
+    public Mono<Boolean> cancelPaymentTimer(Long reservationId) {
+        String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
+        return redisTemplate.delete(timerKey)
+                .map(deleted -> deleted > 0)
+                .doOnSuccess(success -> log.info("결제 타이머 취소: reservationId={}", reservationId));
+    }
+
+    // 남은 시간 조회 (초 단위)
+    // Redis 키가 없으면 -> 타이머 만료 또는 미시작 -> PAYMENT_TIMEOUT 에러
+    public Mono<Long> getRemainingTime(Long reservationId) {
+        String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
+        return redisTemplate.getExpire(timerKey)
+                .flatMap(duration -> {
+                    long seconds = duration.getSeconds();
+                    // Redis 키 없음: -1(키 없음) 또는 -2(만료됨) 반환
+                    if (seconds < 0) {
+                        return Mono.error(new BusinessException(ErrorCode.PAYMENT_TIMEOUT));
+                    }
+                    return Mono.just(seconds);
+                });
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentVerificationScheduler.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentVerificationScheduler.java
@@ -1,0 +1,73 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.domain.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentVerificationScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final PortOneClient portOneClient;
+
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    public void verifyPendingPayments() {
+        try {
+            LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+
+            paymentRepository.findByStatus(PaymentStatus.PENDING.name())
+                    .filter(payment -> payment.getCreatedAt() != null
+                            && payment.getCreatedAt().isBefore(threshold))
+                    .filter(payment -> payment.getMerchantUid() != null)
+                    .flatMap(payment -> portOneClient.verifyPayment(payment.getMerchantUid())
+                            .flatMap(verification -> {
+                                switch (verification.getStatus()) {
+                                    case COMPLETED -> {
+                                        log.info("결제 불일치 복구 - 완료 처리: paymentId={}",
+                                                payment.getId());
+                                        payment.setStatus(PaymentStatus.COMPLETED.name());
+                                        payment.setPaidAt(LocalDateTime.now());
+                                        payment.setUpdatedAt(LocalDateTime.now());
+                                        return paymentRepository.save(payment);
+                                    }
+                                    case FAILED -> {
+                                        log.warn("결제 불일치 복구 - 실패 처리: paymentId={}",
+                                                payment.getId());
+                                        payment.setStatus(PaymentStatus.FAILED.name());
+                                        payment.setUpdatedAt(LocalDateTime.now());
+                                        return paymentRepository.save(payment);
+                                    }
+                                    default -> {
+                                        log.debug("결제 검증 대기 중: paymentId={}, status={}",
+                                                payment.getId(), verification.getStatus());
+                                        return reactor.core.publisher.Mono.just(payment);
+                                    }
+                                }
+                            })
+                            .onErrorResume(e -> {
+                                log.warn("결제 검증 API 호출 실패: paymentId={}, error={}",
+                                        payment.getId(), e.getMessage());
+                                return reactor.core.publisher.Mono.just(payment);
+                            }))
+                    .count()
+                    .doOnSuccess(count -> {
+                        if (count > 0) {
+                            log.info("결제 불일치 복구 처리: {}건", count);
+                        }
+                    })
+                    .block(Duration.ofSeconds(30));
+
+        } catch (Exception e) {
+            log.error("결제 불일치 복구 스케줄러 오류", e);
+        }
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/service/PortOneClient.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PortOneClient.java
@@ -1,0 +1,131 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.global.exception.BusinessException;
+import com.opentraum.payment.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings("unchecked")
+public class PortOneClient {
+
+    private WebClient webClient;
+
+    @Value("${opentraum.portone.api-secret}")
+    private String apiSecret;
+
+    private static final String PORTONE_API_URL = "https://api.portone.io";
+
+    @PostConstruct
+    public void init() {
+        this.webClient = WebClient.builder()
+                .baseUrl(PORTONE_API_URL)
+                .defaultHeader("Authorization", "PortOne " + apiSecret)
+                .build();
+    }
+
+    /**
+     * 결제 검증 (V2)
+     * paymentId = FE에서 PortOne.requestPayment()에 넘긴 paymentId (= 우리 merchantUid)
+     */
+    public Mono<PaymentVerificationResult> verifyPayment(String paymentId) {
+        return webClient.get()
+                .uri("/payments/{paymentId}", paymentId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .<PaymentVerificationResult>map(response -> {
+                    Map<String, Object> amount = (Map<String, Object>) response.get("amount");
+                    return PaymentVerificationResult.builder()
+                            .paymentId((String) response.get("id"))
+                            .transactionId((String) response.get("transactionId"))
+                            .amount(((Number) amount.get("total")).intValue())
+                            .status(mapStatus((String) response.get("status")))
+                            .build();
+                })
+                .doOnSuccess(result -> log.info("결제 검증 완료: paymentId={}, status={}",
+                        paymentId, result.getStatus()))
+                .onErrorResume(WebClientResponseException.class, e -> {
+                    log.error("PortOne 결제 검증 실패: paymentId={}, status={}, body={}",
+                            paymentId, e.getStatusCode(), e.getResponseBodyAsString());
+                    return Mono.error(new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH,
+                            "PortOne 결제 검증 실패: " + e.getResponseBodyAsString()));
+                })
+                .onErrorResume(e -> !(e instanceof BusinessException), e -> {
+                    log.error("PortOne 결제 검증 중 오류: paymentId={}, error={}", paymentId, e.getMessage());
+                    return Mono.error(new BusinessException(ErrorCode.INTERNAL_ERROR,
+                            "PortOne 결제 검증 오류: " + e.getMessage()));
+                });
+    }
+
+    /**
+     * 결제 취소/환불 (V2)
+     * paymentId = 우리 merchantUid
+     */
+    public Mono<RefundResult> cancelPayment(String paymentId, int amount, String reason) {
+        return webClient.post()
+                .uri("/payments/{paymentId}/cancel", paymentId)
+                .bodyValue(Map.of(
+                        "amount", amount,
+                        "reason", reason
+                ))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .<RefundResult>map(response -> {
+                    Map<String, Object> cancellation = (Map<String, Object>) response.get("cancellation");
+                    String status = cancellation != null ? (String) cancellation.get("status") : "FAILED";
+                    return RefundResult.builder()
+                            .success("SUCCEEDED".equals(status))
+                            .message(reason)
+                            .build();
+                })
+                .doOnSuccess(result -> log.info("환불 처리 완료: paymentId={}, success={}",
+                        paymentId, result.isSuccess()))
+                .onErrorResume(WebClientResponseException.class, e -> {
+                    log.error("PortOne 환불 실패: paymentId={}, status={}, body={}",
+                            paymentId, e.getStatusCode(), e.getResponseBodyAsString());
+                    return Mono.error(new BusinessException(ErrorCode.REFUND_FAILED,
+                            "PortOne 환불 실패: " + e.getResponseBodyAsString()));
+                })
+                .onErrorResume(e -> !(e instanceof BusinessException), e -> {
+                    log.error("PortOne 환불 중 오류: paymentId={}, error={}", paymentId, e.getMessage());
+                    return Mono.error(new BusinessException(ErrorCode.REFUND_FAILED,
+                            "PortOne 환불 오류: " + e.getMessage()));
+                });
+    }
+
+    private PaymentStatus mapStatus(String portoneStatus) {
+        return switch (portoneStatus) {
+            case "PAID"      -> PaymentStatus.COMPLETED;
+            case "CANCELLED" -> PaymentStatus.REFUNDED;
+            case "FAILED"    -> PaymentStatus.FAILED;
+            default          -> PaymentStatus.PENDING;
+        };
+    }
+
+    @lombok.Builder
+    @lombok.Getter
+    public static class PaymentVerificationResult {
+        private String paymentId;
+        private String transactionId;
+        private Integer amount;
+        private PaymentStatus status;
+    }
+
+    @lombok.Builder
+    @lombok.Getter
+    public static class RefundResult {
+        private boolean success;
+        private String message;
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/service/RefundConsumer.java
+++ b/src/main/java/com/opentraum/payment/domain/service/RefundConsumer.java
@@ -1,0 +1,32 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.config.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * refund 토픽 Consumer
+ * 실제 환불 처리 로직 연결은 추후 이슈에서 진행
+ */
+@Slf4j
+@Component
+public class RefundConsumer {
+
+    @KafkaListener(
+            topics = KafkaTopics.REFUND,
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleRefund(
+            @Payload String message,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.OFFSET) long offset) {
+        log.info("[Kafka] refund 수신: topic={}, offset={}, message={}",
+                topic, offset, message);
+
+        // TODO: 실제 환불 처리 로직 연결 (추후 이슈)
+    }
+}

--- a/src/main/java/com/opentraum/payment/global/exception/BusinessException.java
+++ b/src/main/java/com/opentraum/payment/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.opentraum.payment.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/opentraum/payment/global/exception/ErrorCode.java
+++ b/src/main/java/com/opentraum/payment/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.opentraum.payment.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 오류가 발생했습니다"),
+
+    // Payment
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "결제 정보를 찾을 수 없습니다"),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P002", "결제 금액이 일치하지 않습니다"),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "P003", "이미 완료된 결제입니다"),
+    PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "P004", "결제 시간이 초과되었습니다"),
+    REFUND_FAILED(HttpStatus.BAD_REQUEST, "P005", "환불 처리에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/opentraum/payment/global/exception/ErrorResponse.java
+++ b/src/main/java/com/opentraum/payment/global/exception/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.opentraum.payment.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/opentraum/payment/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/opentraum/payment/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.opentraum.payment.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(WebExchangeBindException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("입력값이 올바르지 않습니다");
+
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected Exception: ", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR));
+    }
+}

--- a/src/main/java/com/opentraum/payment/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/opentraum/payment/global/util/RedisKeyGenerator.java
@@ -1,0 +1,22 @@
+package com.opentraum.payment.global.util;
+
+/**
+ * Redis 키 생성을 위한 유틸리티 클래스 (결제 서비스 전용)
+ */
+public class RedisKeyGenerator {
+
+    private RedisKeyGenerator() {
+        throw new UnsupportedOperationException("유틸리티 클래스는 인스턴스화할 수 없습니다.");
+    }
+
+    // 미결제 자동 취소 타이머 키 (String+TTL) - payment-timer:{reservationId}
+    public static String paymentTimerKey(Long reservationId) {
+        return String.format("payment-timer:%d", reservationId);
+    }
+
+    // 등급별 잔여 재고 카운터 키 (String, atomic INCR/DECR 전용)
+    // stock:{scheduleId}:{grade}
+    public static String stockKey(Long scheduleId, String grade) {
+        return String.format("stock:%d:%s", scheduleId, grade);
+    }
+}


### PR DESCRIPTION
## 개요
FairTicket 모놀리스의 Payment 도메인을 payment-service MSA로 마이그레이션합니다.
Closes #3

## 변경 사항
- Payment 엔티티 리팩토링 (FairTicket 구조: merchantUid, impUid, pgTid)
- PaymentStatus enum (PENDING/COMPLETED/FAILED/CANCELLED/REFUNDED)
- PaymentService: 결제 초기화/완료/웹훅 처리
- PortOneClient: WebClient 기반 PG사 API 연동
- PaymentTimerService: Redis 기반 결제 만료 타이머
- PaymentExpiryScheduler: 미결제 자동 취소
- PaymentVerificationScheduler: PG사 결제 상태 검증
- PaymentEventProducer: Kafka 결제 이벤트 발행
- RefundConsumer: Kafka 환불 이벤트 수신
- PaymentQueryRepository: DatabaseClient JOIN 쿼리
- BusinessException 글로벌 예외 처리
- KafkaTopics 상수, Swagger/OpenAPI 설정

## 테스트 계획
- [ ] 결제 초기화 API 동작 확인
- [ ] 결제 완료 → 상태 변경 확인
- [ ] Redis 타이머 동작 확인
- [ ] Kafka 이벤트 발행/수신 확인