### PR TITLE
feat: PostgreSQL → MariaDB 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,8 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
-    // R2DBC PostgreSQL
-    runtimeOnly 'org.postgresql:r2dbc-postgresql'
-    runtimeOnly 'org.postgresql:postgresql'
+    // R2DBC MariaDB
+    runtimeOnly 'io.asyncer:r2dbc-mysql:1.1.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     name: opentraum-payment-service
 
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/opentraum_payment
     username: ${DB_USERNAME:opentraum}
-    password: ${DB_PASSWORD:opentraum}
+    password: ${DB_PASSWORD:opentraum123!}
 
   sql:
     init:
@@ -62,7 +62,7 @@ spring:
     activate:
       on-profile: dev
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+    url: r2dbc:mariadb://localhost:3306/opentraum_payment
 
 ---
 spring:
@@ -70,4 +70,4 @@ spring:
     activate:
       on-profile: prod
   r2dbc:
-    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/opentraum_payment
+    url: r2dbc:mariadb://${DB_HOST}:${DB_PORT}/opentraum_payment

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,6 @@
 -- 결제 테이블 (FairTicket 마이그레이션 + tenantId 추가)
 CREATE TABLE IF NOT EXISTS payments (
-    id BIGSERIAL PRIMARY KEY,
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
     reservation_id BIGINT NOT NULL,
     user_id BIGINT,
     merchant_uid VARCHAR(100) UNIQUE NOT NULL,
@@ -16,12 +16,12 @@ CREATE TABLE IF NOT EXISTS payments (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_payments_reservation_completed
-    ON payments(reservation_id) WHERE status = 'COMPLETED';
+CREATE INDEX idx_payments_reservation_completed
+    ON payments(reservation_id);
 
-CREATE INDEX IF NOT EXISTS idx_payments_reservation_id ON payments(reservation_id);
-CREATE INDEX IF NOT EXISTS idx_payments_tenant_id ON payments(tenant_id);
-CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status);
-CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);
-CREATE INDEX IF NOT EXISTS idx_payments_merchant_uid ON payments(merchant_uid);
-CREATE INDEX IF NOT EXISTS idx_payments_imp_uid ON payments(imp_uid);
+CREATE INDEX idx_payments_reservation_id ON payments(reservation_id);
+CREATE INDEX idx_payments_tenant_id ON payments(tenant_id);
+CREATE INDEX idx_payments_status ON payments(status);
+CREATE INDEX idx_payments_user_id ON payments(user_id);
+CREATE INDEX idx_payments_merchant_uid ON payments(merchant_uid);
+CREATE INDEX idx_payments_imp_uid ON payments(imp_uid);


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 드라이버 전환
- SKALA 미니프로젝트 1+2 (대량 요청 처리 + CDC) 대비

## Changes
- `r2dbc-postgresql` → `io.asyncer:r2dbc-mysql:1.1.0`
- connection string → `r2dbc:mariadb://opentraum-mariadb:3306`
- schema.sql MariaDB 호환 문법 전환

## Test plan
- [x] MariaDB Pod Running 확인
- [x] 서비스 Pod Running 확인 (새 이미지)
- [ ] /actuator/health 200 응답 확인
- [ ] CRUD API 정상 동작 확인