### PR TITLE
feat: 결제 테이블 중복 데이터 + 처리 지연 (CDC 대비)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,8 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
-    // R2DBC PostgreSQL
-    runtimeOnly 'org.postgresql:r2dbc-postgresql'
-    runtimeOnly 'org.postgresql:postgresql'
+    // R2DBC MariaDB
+    runtimeOnly 'io.asyncer:r2dbc-mysql:1.1.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/opentraum/payment/config/WebClientConfig.java
+++ b/src/main/java/com/opentraum/payment/config/WebClientConfig.java
@@ -1,0 +1,22 @@
+package com.opentraum.payment.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient reservationWebClient(
+            @Value("${opentraum.services.reservation-url:http://reservation-service:8084}") String baseUrl) {
+        return WebClient.builder().baseUrl(baseUrl).build();
+    }
+
+    @Bean
+    public WebClient eventWebClient(
+            @Value("${opentraum.services.event-url:http://event-service:8083}") String baseUrl) {
+        return WebClient.builder().baseUrl(baseUrl).build();
+    }
+}

--- a/src/main/java/com/opentraum/payment/domain/entity/Payment.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/Payment.java
@@ -39,6 +39,23 @@ public class Payment {
 
     private Long tenantId;
 
+    // 주문(reservation) 데이터 복제 (CDC 대비)
+    private String reservationStatus;
+
+    private Integer reservationQuantity;
+
+    private String reservationGrade;
+
+    // 이벤트(product) 데이터 복제 (CDC 대비)
+    private String eventTitle;
+
+    private String eventArtist;
+
+    private String eventVenue;
+
+    // 처리 시간 추적
+    private Long elapsedMs;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
@@ -11,27 +11,51 @@ import com.opentraum.payment.global.exception.BusinessException;
 import com.opentraum.payment.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentQueryRepository paymentQueryRepository;
     private final PortOneClient portOneClient;
     private final PaymentTimerService timerService;
+    private final WebClient reservationWebClient;
+    private final WebClient eventWebClient;
+    private final long paymentDelayMs;
 
-    // 결제 준비 (결제창 호출 전)
+    public PaymentService(PaymentRepository paymentRepository,
+                          PaymentQueryRepository paymentQueryRepository,
+                          PortOneClient portOneClient,
+                          PaymentTimerService timerService,
+                          @Qualifier("reservationWebClient") WebClient reservationWebClient,
+                          @Qualifier("eventWebClient") WebClient eventWebClient,
+                          @Value("${opentraum.payment.delay-ms:2000}") long paymentDelayMs) {
+        this.paymentRepository = paymentRepository;
+        this.paymentQueryRepository = paymentQueryRepository;
+        this.portOneClient = portOneClient;
+        this.timerService = timerService;
+        this.reservationWebClient = reservationWebClient;
+        this.eventWebClient = eventWebClient;
+        this.paymentDelayMs = paymentDelayMs;
+    }
+
+    // 결제 준비 (결제창 호출 전) — 주문/이벤트 데이터 복제 + 지연
     public Mono<PaymentInitResponse> initiatePayment(Long reservationId, Integer amount,
                                                       String itemName, Long tenantId, Long userId) {
         String merchantUid = generateMerchantUid();
+        long startTime = System.currentTimeMillis();
 
         Payment payment = Payment.builder()
                 .reservationId(reservationId)
@@ -43,7 +67,20 @@ public class PaymentService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        return paymentRepository.save(payment)
+        // 주문/이벤트 데이터 복제 조회 (best-effort)
+        Mono<Payment> enriched = enrichWithReservationData(payment, reservationId)
+                .onErrorResume(e -> {
+                    log.warn("주문 데이터 복제 실패 (무시): {}", e.getMessage());
+                    return Mono.just(payment);
+                });
+
+        return enriched
+                // 결제 처리 지연 (HPA Scale Out 유도)
+                .delayElement(Duration.ofMillis(paymentDelayMs))
+                .flatMap(p -> {
+                    p.setElapsedMs(System.currentTimeMillis() - startTime);
+                    return paymentRepository.save(p);
+                })
                 .flatMap(saved -> timerService.startPaymentTimer(reservationId)
                         .thenReturn(saved))
                 .map(saved -> PaymentInitResponse.builder()
@@ -53,6 +90,46 @@ public class PaymentService {
                         .itemName(itemName)
                         .timeoutSeconds(PaymentConstants.PAYMENT_DEADLINE_MINUTES * 60)
                         .build());
+    }
+
+    // 주문(reservation) 데이터를 payment에 복제
+    private Mono<Payment> enrichWithReservationData(Payment payment, Long reservationId) {
+        return reservationWebClient.get()
+                .uri("/api/v1/reservations/{id}", reservationId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .flatMap(reservation -> {
+                    payment.setReservationStatus((String) reservation.get("status"));
+                    payment.setReservationQuantity((Integer) reservation.get("quantity"));
+                    payment.setReservationGrade((String) reservation.get("grade"));
+
+                    // 이벤트(스케줄→콘서트) 데이터도 복제 시도
+                    Object scheduleId = reservation.get("scheduleId");
+                    if (scheduleId != null) {
+                        return enrichWithEventData(payment, Long.valueOf(scheduleId.toString()));
+                    }
+                    return Mono.just(payment);
+                })
+                .defaultIfEmpty(payment);
+    }
+
+    // 이벤트(product) 데이터를 payment에 복제
+    private Mono<Payment> enrichWithEventData(Payment payment, Long scheduleId) {
+        return eventWebClient.get()
+                .uri("/api/v1/schedules/{id}", scheduleId)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(schedule -> {
+                    payment.setEventTitle((String) schedule.get("concertTitle"));
+                    payment.setEventArtist((String) schedule.get("artist"));
+                    payment.setEventVenue((String) schedule.get("venue"));
+                    return payment;
+                })
+                .defaultIfEmpty(payment)
+                .onErrorResume(e -> {
+                    log.warn("이벤트 데이터 복제 실패 (무시): {}", e.getMessage());
+                    return Mono.just(payment);
+                });
     }
 
     // 결제 완료 처리 - PortOne Webhook 수신

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     name: opentraum-payment-service
 
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/opentraum_payment
     username: ${DB_USERNAME:opentraum}
-    password: ${DB_PASSWORD:opentraum}
+    password: ${DB_PASSWORD:opentraum123!}
 
   sql:
     init:
@@ -62,7 +62,7 @@ spring:
     activate:
       on-profile: dev
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_payment
+    url: r2dbc:mariadb://localhost:3306/opentraum_payment
 
 ---
 spring:
@@ -70,4 +70,4 @@ spring:
     activate:
       on-profile: prod
   r2dbc:
-    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/opentraum_payment
+    url: r2dbc:mariadb://${DB_HOST}:${DB_PORT}/opentraum_payment

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,11 @@ opentraum:
   portone:
     api-secret: ${PORTONE_API_SECRET:test-api-secret}
     store-id: ${PORTONE_STORE_ID:test-store-id}
+  services:
+    reservation-url: ${RESERVATION_SERVICE_URL:http://reservation-service:8084}
+    event-url: ${EVENT_SERVICE_URL:http://event-service:8083}
+  payment:
+    delay-ms: ${PAYMENT_DELAY_MS:2000}
 
 # Swagger
 springdoc:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,6 @@
 -- 결제 테이블 (FairTicket 마이그레이션 + tenantId 추가)
 CREATE TABLE IF NOT EXISTS payments (
-    id BIGSERIAL PRIMARY KEY,
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
     reservation_id BIGINT NOT NULL,
     user_id BIGINT,
     merchant_uid VARCHAR(100) UNIQUE NOT NULL,
@@ -16,12 +16,12 @@ CREATE TABLE IF NOT EXISTS payments (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_payments_reservation_completed
-    ON payments(reservation_id) WHERE status = 'COMPLETED';
+CREATE INDEX idx_payments_reservation_completed
+    ON payments(reservation_id);
 
-CREATE INDEX IF NOT EXISTS idx_payments_reservation_id ON payments(reservation_id);
-CREATE INDEX IF NOT EXISTS idx_payments_tenant_id ON payments(tenant_id);
-CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status);
-CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);
-CREATE INDEX IF NOT EXISTS idx_payments_merchant_uid ON payments(merchant_uid);
-CREATE INDEX IF NOT EXISTS idx_payments_imp_uid ON payments(imp_uid);
+CREATE INDEX idx_payments_reservation_id ON payments(reservation_id);
+CREATE INDEX idx_payments_tenant_id ON payments(tenant_id);
+CREATE INDEX idx_payments_status ON payments(status);
+CREATE INDEX idx_payments_user_id ON payments(user_id);
+CREATE INDEX idx_payments_merchant_uid ON payments(merchant_uid);
+CREATE INDEX idx_payments_imp_uid ON payments(imp_uid);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
--- 결제 테이블 (FairTicket 마이그레이션 + tenantId 추가)
+-- 결제 테이블 (FairTicket 마이그레이션 + tenantId 추가 + CDC 중복 데이터)
 CREATE TABLE IF NOT EXISTS payments (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     reservation_id BIGINT NOT NULL,
@@ -12,6 +12,16 @@ CREATE TABLE IF NOT EXISTS payments (
     expires_at TIMESTAMP,
     paid_at TIMESTAMP,
     tenant_id BIGINT NOT NULL,
+    -- 주문(reservation) 데이터 복제 (CDC 대비)
+    reservation_status VARCHAR(20),
+    reservation_quantity INT,
+    reservation_grade VARCHAR(50),
+    -- 이벤트(product) 데이터 복제 (CDC 대비)
+    event_title VARCHAR(255),
+    event_artist VARCHAR(255),
+    event_venue VARCHAR(255),
+    -- 처리 시간 추적
+    elapsed_ms BIGINT DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- 결제 테이블에 주문/이벤트 데이터 복제 컬럼 추가 (CDC 대비)
- 결제 처리 시 2초 지연 → HPA Scale Out 유도
- WebClient로 reservation/event 서비스 데이터 조회 → 복제 저장

## Test plan
- [ ] payment-service Pod Running 확인
- [ ] 결제 API 호출 시 2초 지연 확인
- [ ] payments 테이블에 복제 컬럼 데이터 저장 확인