### PR TITLE
fix: K8s deployment.yml 클러스터 상태 동기화

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -19,11 +19,39 @@ spec:
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: payment
     spec:
+      terminationGracePeriodSeconds: 10
       imagePullSecrets:
         - name: harbor-secret
+      priorityClassName: opentraum-high
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - reservation-service
+                        - payment-service
+                        - event-service
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - payment-service
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: payment-service
           image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-payment-service:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8085
               protocol: TCP
@@ -31,29 +59,49 @@ spec:
             - configMapRef:
                 name: opentraum-config
           env:
-            - name: SPRING_DATASOURCE_URL
-              value: "jdbc:postgresql://opentraum-postgres:5432/opentraum_payment"
+            - name: DB_HOST
+              value: "opentraum-mariadb.mariadb"
+            - name: DB_PORT
+              value: "3306"
+            - name: DB_NAME
+              value: "opentraum_payment"
+            - name: DB_USERNAME
+              value: "opentraum"
+            - name: DB_PASSWORD
+              value: "opentraum123!"
+            - name: SPRING_R2DBC_URL
+              value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_payment"
+            - name: JAVA_OPTS
+              value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+            - name: SPRING_MAIN_LAZY_INITIALIZATION
+              value: "true"
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "250m"
-            limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8085
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 3
+            failureThreshold: 20
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8085
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            timeoutSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8085
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
       restartPolicy: Always


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 연결 (r2dbc:mysql://opentraum-mariadb.mariadb)
- NS 분리 FQDN 반영 (mariadb, kafka, redis)
- QoS=Guaranteed, PriorityClass, startupProbe 추가