### PR TITLE
feat: k8s 매니페스트 운영 설정 반영

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,10 +5,12 @@ metadata:
   namespace: opentraum
   labels:
     app: payment-service
+    app.kubernetes.io/name: payment-service
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: payment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: payment-service
@@ -16,10 +18,11 @@ spec:
     metadata:
       labels:
         app: payment-service
+        app.kubernetes.io/name: payment-service
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: payment
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 40
       imagePullSecrets:
         - name: harbor-secret
       priorityClassName: opentraum-high
@@ -43,11 +46,18 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
+                    - key: app.kubernetes.io/name
                       operator: In
                       values:
                         - payment-service
                 topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: opentraum
       containers:
         - name: payment-service
           image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-payment-service:latest
@@ -59,22 +69,28 @@ spec:
             - configMapRef:
                 name: opentraum-config
           env:
-            - name: DB_HOST
-              value: "opentraum-mariadb.mariadb"
-            - name: DB_PORT
-              value: "3306"
-            - name: DB_NAME
-              value: "opentraum_payment"
-            - name: DB_USERNAME
-              value: "opentraum"
-            - name: DB_PASSWORD
-              value: "opentraum123!"
             - name: SPRING_R2DBC_URL
-              value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_payment"
+              value: "r2dbc:mysql://payment-db.kafka:3306/payment"
+            - name: SPRING_R2DBC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: payment-db-secret
+                  key: mariadb-user
+            - name: SPRING_R2DBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: payment-db-secret
+                  key: mariadb-password
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: "my-kafka-cluster-kafka-bootstrap.kafka:9092"
+            - name: OTLP_TRACING_ENDPOINT
+              value: "http://alloy-otlp.monitoring:4318/v1/traces"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod,mock"
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
-              value: "true"
+              value: "false"
           resources:
             requests:
               memory: "512Mi"
@@ -82,26 +98,4 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
-          startupProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8085
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            timeoutSeconds: 3
-            failureThreshold: 20
-          livenessProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8085
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8085
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 2
       restartPolicy: Always


### PR DESCRIPTION
## Summary
- DB 호스트 변경: `opentraum-mariadb.mariadb` → `payment-db.kafka` (CDC per-service DB)
- DB credentials 평문 → `payment-db-secret` Secret 참조
- KAFKA_BOOTSTRAP_SERVERS, OTLP_TRACING_ENDPOINT env 추가
- SPRING_PROFILES_ACTIVE `prod,mock` 추가 (PortOne Mock)
- topologySpreadConstraints 추가
- terminationGracePeriodSeconds 10 → 40
- SPRING_MAIN_LAZY_INITIALIZATION true → false
- 기존 평문 DB env / Probe 제거
- 라벨 `app.kubernetes.io/name`, `revisionHistoryLimit: 2` 추가

## Why
OpenTraum-Infra `k8s-manual/payment-service/` 의 운영 설정을 본 레포 `k8s/` 로 이관해 ArgoCD GitOps 자동 배포 전환 준비를 완료합니다.

## Test plan
- [ ] `payment-db-secret` 클러스터 배포 + `payment-db.kafka` 가용성 확인 후 ArgoCD sync
- [ ] PortOne Mock 동작 확인 (`SPRING_PROFILES_ACTIVE=prod,mock`)
- [ ] 새 Pod env 에 Secret / OTLP / KAFKA_BOOTSTRAP_SERVERS 정상 주입 확인

Closes #19