### PR TITLE
feat: payment.tenant_id String 통일 + SAGA tenant 전파 + 매출 조회 API

### DIFF
--- a/src/main/java/com/opentraum/payment/domain/controller/PaymentController.java
+++ b/src/main/java/com/opentraum/payment/domain/controller/PaymentController.java
@@ -2,8 +2,10 @@ package com.opentraum.payment.domain.controller;
 
 import com.opentraum.payment.domain.dto.PaymentInitResponse;
 import com.opentraum.payment.domain.dto.PaymentTimerResponse;
+import com.opentraum.payment.domain.dto.RevenueResponse;
 import com.opentraum.payment.domain.dto.WebhookRequest;
 import com.opentraum.payment.domain.entity.Payment;
+import com.opentraum.payment.domain.repository.PaymentQueryRepository;
 import com.opentraum.payment.domain.service.PaymentService;
 import com.opentraum.payment.domain.service.PaymentTimerService;
 import com.opentraum.payment.domain.client.PortOneClient;
@@ -24,6 +26,7 @@ public class PaymentController {
 
     private final PaymentService paymentService;
     private final PaymentTimerService paymentTimerService;
+    private final PaymentQueryRepository paymentQueryRepository;
 
     @Operation(
             summary = "결제 준비",
@@ -38,7 +41,7 @@ public class PaymentController {
             @Parameter(description = "상품명", required = true)
             @RequestParam String itemName,
             @Parameter(description = "테넌트 ID", required = true)
-            @RequestHeader("X-Tenant-Id") Long tenantId,
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @Parameter(description = "사용자 ID", required = true)
             @RequestHeader("X-User-Id") Long userId) {
         return paymentService.initiatePayment(reservationId, amount, itemName, tenantId, userId)
@@ -135,5 +138,23 @@ public class PaymentController {
                         .remainingSeconds(seconds)
                         .expired(false)
                         .build()));
+    }
+
+    @Operation(
+            summary = "ORGANIZER 매출 조회",
+            description = "X-Tenant-Id 헤더 기준 본인 tenant의 COMPLETED 결제 합산. 환불(REFUNDED)은 제외."
+    )
+    @GetMapping("/admin/revenue")
+    public Mono<ResponseEntity<RevenueResponse>> getOrganizerRevenue(
+            @RequestHeader("X-Tenant-Id") String tenantId) {
+        return Mono.zip(
+                        paymentQueryRepository.sumCompletedAmountByTenantId(tenantId),
+                        paymentQueryRepository.countCompletedByTenantId(tenantId))
+                .map(t -> RevenueResponse.builder()
+                        .tenantId(tenantId)
+                        .totalAmount(t.getT1())
+                        .completedCount(t.getT2())
+                        .build())
+                .map(ResponseEntity::ok);
     }
 }

--- a/src/main/java/com/opentraum/payment/domain/dto/RevenueResponse.java
+++ b/src/main/java/com/opentraum/payment/domain/dto/RevenueResponse.java
@@ -1,0 +1,14 @@
+package com.opentraum.payment.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RevenueResponse {
+    private String tenantId;
+    private long totalAmount;
+    private long completedCount;
+}

--- a/src/main/java/com/opentraum/payment/domain/entity/Payment.java
+++ b/src/main/java/com/opentraum/payment/domain/entity/Payment.java
@@ -37,7 +37,7 @@ public class Payment {
 
     private LocalDateTime paidAt;
 
-    private Long tenantId;
+    private String tenantId;
 
     // 주문(reservation) 데이터 복제 (CDC 대비)
     private String reservationStatus;

--- a/src/main/java/com/opentraum/payment/domain/listener/SeatHeldListener.java
+++ b/src/main/java/com/opentraum/payment/domain/listener/SeatHeldListener.java
@@ -100,6 +100,8 @@ public class SeatHeldListener {
         Integer amount = intOrNull(node, "amount");
         String trackType = textOrDefault(node, "track_type", "LIVE");
         String impUid = textOrDefault(node, "imp_uid", "saga-" + reservationId);
+        // event-service의 SeatSagaService.publishSeatHeld가 schedule.tenant_id를 자동 머지함
+        String tenantId = textOrNull(node, "tenant_id");
 
         return paymentSagaService.process(
                         reservationId,
@@ -108,7 +110,8 @@ public class SeatHeldListener {
                         scheduleId,
                         amount,
                         trackType,
-                        impUid)
+                        impUid,
+                        tenantId)
                 .then(idempotencyService.markProcessed(eventId, CONSUMER_GROUP));
     }
 

--- a/src/main/java/com/opentraum/payment/domain/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/opentraum/payment/domain/repository/PaymentQueryRepository.java
@@ -14,6 +14,37 @@ public class PaymentQueryRepository {
 
     private final DatabaseClient databaseClient;
 
+    /**
+     * ORGANIZER 매출 합산 (status=COMPLETED 인 payments의 amount 총합).
+     * 환불(REFUNDED)은 제외한다.
+     */
+    public reactor.core.publisher.Mono<Long> sumCompletedAmountByTenantId(String tenantId) {
+        return databaseClient.sql("""
+                SELECT COALESCE(SUM(amount), 0) AS total
+                FROM payments
+                WHERE tenant_id = :tenantId AND status = 'COMPLETED'
+                """)
+                .bind("tenantId", tenantId)
+                .map((row, metadata) -> row.get("total", Long.class))
+                .one()
+                .defaultIfEmpty(0L);
+    }
+
+    /**
+     * ORGANIZER 매출 건수 (status=COMPLETED).
+     */
+    public reactor.core.publisher.Mono<Long> countCompletedByTenantId(String tenantId) {
+        return databaseClient.sql("""
+                SELECT COUNT(*) AS cnt
+                FROM payments
+                WHERE tenant_id = :tenantId AND status = 'COMPLETED'
+                """)
+                .bind("tenantId", tenantId)
+                .map((row, metadata) -> row.get("cnt", Long.class))
+                .one()
+                .defaultIfEmpty(0L);
+    }
+
     public Flux<Payment> findByUserId(Long userId) {
         return databaseClient.sql("""
                 SELECT * FROM payments
@@ -29,7 +60,7 @@ public class PaymentQueryRepository {
                         .impUid(row.get("imp_uid", String.class))
                         .amount(row.get("amount", Integer.class))
                         .status(row.get("status", String.class))
-                        .tenantId(row.get("tenant_id", Long.class))
+                        .tenantId(row.get("tenant_id", String.class))
                         .paidAt(row.get("paid_at", LocalDateTime.class))
                         .createdAt(row.get("created_at", LocalDateTime.class))
                         .updatedAt(row.get("updated_at", LocalDateTime.class))

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentSagaService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentSagaService.java
@@ -51,15 +51,16 @@ public class PaymentSagaService {
             Long scheduleId,
             Integer amount,
             String trackType,
-            String impUid
+            String impUid,
+            String tenantId
     ) {
-        log.info("[SAGA] payment start: reservationId={}, sagaId={}, track={}, amount={}",
-                reservationId, sagaId, trackType, amount);
+        log.info("[SAGA] payment start: reservationId={}, sagaId={}, track={}, amount={}, tenantId={}",
+                reservationId, sagaId, trackType, amount, tenantId);
 
         // 1. PortOne 호출 (트랜잭션 밖)
         return portOneClient.verifyPayment(impUid)
-                .flatMap(result -> onSuccess(reservationId, sagaId, userId, amount, trackType, impUid, result))
-                .onErrorResume(err -> onFailure(reservationId, sagaId, userId, amount, impUid, err))
+                .flatMap(result -> onSuccess(reservationId, sagaId, userId, amount, trackType, impUid, tenantId, result))
+                .onErrorResume(err -> onFailure(reservationId, sagaId, userId, amount, impUid, tenantId, err))
                 .then();
     }
 
@@ -70,9 +71,10 @@ public class PaymentSagaService {
             Integer amount,
             String trackType,
             String impUid,
+            String tenantId,
             PortOneClient.PaymentVerificationResult verification
     ) {
-        Mono<Void> tx = upsertPayment(reservationId, userId, amount, impUid, PaymentStatus.COMPLETED)
+        Mono<Void> tx = upsertPayment(reservationId, userId, amount, impUid, tenantId, PaymentStatus.COMPLETED)
                 .flatMap(payment -> {
                     Map<String, Object> payload = new LinkedHashMap<>();
                     payload.put("payment_id", payment.getId());
@@ -96,7 +98,7 @@ public class PaymentSagaService {
                     // 트랜잭션(또는 outbox write) 자체가 실패한 상황 -> Failed 쪽으로도 시도
                     log.error("[SAGA] PaymentCompleted 기록 실패, PaymentFailed로 전환: reservationId={}, err={}",
                             reservationId, err.getMessage());
-                    return onFailure(reservationId, sagaId, userId, amount, impUid, err);
+                    return onFailure(reservationId, sagaId, userId, amount, impUid, tenantId, err);
                 });
     }
 
@@ -106,13 +108,14 @@ public class PaymentSagaService {
             Long userId,
             Integer amount,
             String impUid,
+            String tenantId,
             Throwable err
     ) {
         String reason = classifyFailure(err);
         log.warn("[SAGA] PaymentFailed: reservationId={}, sagaId={}, reason={}, err={}",
                 reservationId, sagaId, reason, err.getMessage());
 
-        Mono<Void> tx = upsertPayment(reservationId, userId, amount, impUid, PaymentStatus.FAILED)
+        Mono<Void> tx = upsertPayment(reservationId, userId, amount, impUid, tenantId, PaymentStatus.FAILED)
                 .flatMap(payment -> {
                     Map<String, Object> payload = new LinkedHashMap<>();
                     payload.put("payment_id", null);
@@ -144,14 +147,19 @@ public class PaymentSagaService {
             Long userId,
             Integer amount,
             String impUid,
+            String tenantId,
             PaymentStatus status
     ) {
         LocalDateTime now = LocalDateTime.now();
+        String effectiveTenantId = tenantId != null ? tenantId : "default";
         return paymentRepository.findByReservationId(reservationId)
                 .flatMap(existing -> {
                     existing.setStatus(status.name());
                     existing.setImpUid(impUid);
                     existing.setUpdatedAt(now);
+                    if (existing.getTenantId() == null || "default".equals(existing.getTenantId())) {
+                        existing.setTenantId(effectiveTenantId);
+                    }
                     if (status == PaymentStatus.COMPLETED) {
                         existing.setPaidAt(now);
                     }
@@ -165,7 +173,7 @@ public class PaymentSagaService {
                             .impUid(impUid)
                             .merchantUid(impUid != null ? impUid : "SAGA_" + reservationId)
                             .status(status.name())
-                            .tenantId(0L)
+                            .tenantId(effectiveTenantId)
                             .paidAt(status == PaymentStatus.COMPLETED ? now : null)
                             .createdAt(now)
                             .updatedAt(now)

--- a/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
@@ -54,7 +54,7 @@ public class PaymentService {
 
     // 결제 준비 (결제창 호출 전) — 주문/이벤트 데이터 복제 + 지연
     public Mono<PaymentInitResponse> initiatePayment(Long reservationId, Integer amount,
-                                                      String itemName, Long tenantId, Long userId) {
+                                                      String itemName, String tenantId, Long userId) {
         String merchantUid = generateMerchantUid();
         long startTime = System.currentTimeMillis();
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS payments (
     status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
     expires_at TIMESTAMP,
     paid_at TIMESTAMP,
-    tenant_id BIGINT NOT NULL,
+    tenant_id VARCHAR(64) NOT NULL DEFAULT 'default',
     -- 주문(reservation) 데이터 복제 (CDC 대비)
     reservation_status VARCHAR(20),
     reservation_quantity INT,


### PR DESCRIPTION
## 배경

멀티테넌시 모델이 코드에 정의만 있고 실데이터에선 동작 안 함 (payment.tenant_id가 모두 0L 하드코딩).
ORGANIZER 매출 조회를 위해 tenant 모델을 처음으로 진짜 동작시킴.

## 변경 내용

### 데이터 모델 통일
- payments.tenant_id BIGINT → VARCHAR(64), Payment.tenantId Long → String
- PaymentQueryRepository row mapping String

### SAGA tenant 전파
- PaymentSagaService.process/onSuccess/onFailure/upsertPayment에 tenantId 인자
- 0L 하드코딩 제거
- SeatHeldListener.handle: payload에서 tenant_id 추출 (event-service가 자동 머지)

### Controller 시그니처
- PaymentController X-Tenant-Id 헤더 Long → String
- PaymentService.initiatePayment 시그니처 String

### 매출 조회 API (신규)
- \`GET /api/v1/payment/admin/revenue\` (X-Tenant-Id 기준)
- COMPLETED만 합산, REFUNDED 제외
- RevenueResponse DTO

## 검증

\`\`\`
payments 15: tenant_id="org-553275", status=COMPLETED ✅

GET /admin/revenue (X-Tenant-Id: org-553275)
→ {"tenantId":"org-553275","totalAmount":150000,"completedCount":1} ✅
\`\`\`

## 의존성

- event-service의 PR (schedule.tenant_id + SeatHeld payload tenant_id 머지)과 atomic 머지 필요
- payment-db migration: \`ALTER TABLE payments MODIFY tenant_id VARCHAR(64) NOT NULL DEFAULT 'default';\`

TOP 5 잔여 작업 #5의 진짜 해법.