### PR TITLE
fix: TZ=Asia/Seoul env 추가

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -83,6 +83,8 @@ spec:
                   key: mariadb-password
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "my-kafka-cluster-kafka-bootstrap.kafka:9092"
+            - name: TZ
+              value: "Asia/Seoul"
             - name: OTLP_TRACING_ENDPOINT
               value: "http://alloy-otlp.monitoring:4318/v1/traces"
             - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
deployment 컨테이너 TZ를 Asia/Seoul로 통일. LocalDateTime.now()가 KST로 동작하여 사용자가 입력한 ticketOpenAt 등 시간 비교가 정합.