### PR TITLE
chore: 분산 트레이싱(OpenTelemetry/Tempo) 제거 (#26)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,6 @@ dependencies {
     // Monitoring
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    // Tracing (OpenTelemetry via Micrometer bridge)
-    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
-
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
 

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -85,8 +85,6 @@ spec:
               value: "my-kafka-cluster-kafka-bootstrap.kafka:9092"
             - name: TZ
               value: "Asia/Seoul"
-            - name: OTLP_TRACING_ENDPOINT
-              value: "http://alloy-otlp.monitoring:4318/v1/traces"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod,mock"
             - name: JAVA_OPTS

--- a/src/main/java/com/opentraum/payment/PaymentServiceApplication.java
+++ b/src/main/java/com/opentraum/payment/PaymentServiceApplication.java
@@ -9,8 +9,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class PaymentServiceApplication {
 
     public static void main(String[] args) {
-        // Reactor Context <-> MDC/ThreadLocal 자동 전파 (Micrometer Tracing traceId MDC 포함)
-        reactor.core.publisher.Hooks.enableAutomaticContextPropagation();
         SpringApplication.run(PaymentServiceApplication.class, args);
     }
 }

--- a/src/main/java/com/opentraum/payment/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/payment/config/KafkaConfig.java
@@ -63,8 +63,6 @@ public class KafkaConfig {
         factory.setConcurrency(listenerConcurrency);
         // SAGA consumer가 offset을 직접 제어해 exactly-once 경계를 보장한다.
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
-        // Kafka 헤더의 W3C traceparent 복원 -> 현재 span에 바인딩 (Micrometer Tracing 연계)
-        factory.getContainerProperties().setObservationEnabled(true);
         return factory;
     }
 }

--- a/src/main/java/com/opentraum/payment/domain/outbox/entity/OutboxEvent.java
+++ b/src/main/java/com/opentraum/payment/domain/outbox/entity/OutboxEvent.java
@@ -44,9 +44,6 @@ public class OutboxEvent {
     @Column("saga_id")
     private String sagaId;
 
-    @Column("trace_id")
-    private String traceId;
-
     private String payload;
 
     @Column("occurred_at")

--- a/src/main/java/com/opentraum/payment/domain/outbox/service/OutboxService.java
+++ b/src/main/java/com/opentraum/payment/domain/outbox/service/OutboxService.java
@@ -6,11 +6,8 @@ import com.opentraum.payment.domain.outbox.entity.OutboxEvent;
 import com.opentraum.payment.domain.outbox.repository.OutboxRepository;
 import com.opentraum.payment.global.exception.BusinessException;
 import com.opentraum.payment.global.exception.ErrorCode;
-import io.micrometer.tracing.Span;
-import io.micrometer.tracing.Tracer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -40,7 +37,6 @@ public class OutboxService {
 
     private final OutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
-    private final ObjectProvider<Tracer> tracerProvider;
 
     /**
      * Outbox 레코드를 저장한다.
@@ -78,37 +74,21 @@ public class OutboxService {
             return Mono.error(new BusinessException(ErrorCode.INTERNAL_ERROR, "Outbox payload 직렬화 실패"));
         }
 
-        String traceId = currentTraceId();
-
         OutboxEvent event = OutboxEvent.builder()
                 .eventId(eventId)
                 .aggregateId(aggregateId)
                 .aggregateType(aggregateType)
                 .eventType(eventType)
                 .sagaId(sagaId)
-                .traceId(traceId)
                 .payload(json)
                 .occurredAt(occurredAt)
                 .build();
 
         return outboxRepository.save(event)
                 .doOnSuccess(saved -> log.info(
-                        "Outbox 기록: eventId={}, type={}, aggregate={}:{}, sagaId={}, traceId={}",
+                        "Outbox 기록: eventId={}, type={}, aggregate={}:{}, sagaId={}",
                         saved.getEventId(), saved.getEventType(),
-                        saved.getAggregateType(), saved.getAggregateId(), saved.getSagaId(),
-                        saved.getTraceId()
+                        saved.getAggregateType(), saved.getAggregateId(), saved.getSagaId()
                 ));
-    }
-
-    /**
-     * 현재 OpenTelemetry span의 traceId를 반환한다. Tracer Bean이 없거나 active span이 없으면 null.
-     */
-    private String currentTraceId() {
-        Tracer tracer = tracerProvider.getIfAvailable();
-        if (tracer == null) {
-            return null;
-        }
-        Span span = tracer.currentSpan();
-        return span != null ? span.context().traceId() : null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,18 +69,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
-  tracing:
-    sampling:
-      probability: 1.0
-    propagation:
-      type: w3c
-  otlp:
-    tracing:
-      endpoint: ${OTLP_TRACING_ENDPOINT:http://alloy.monitoring:4318/v1/traces}
-
-logging:
-  pattern:
-    level: "%5p [${spring.application.name:payment-service},%X{traceId:-},%X{spanId:-}]"
 
 ---
 spring:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -44,7 +44,6 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     aggregate_type VARCHAR(64) NOT NULL,
     event_type VARCHAR(64) NOT NULL,
     saga_id CHAR(36) NOT NULL,
-    trace_id CHAR(32),
     payload JSON NOT NULL,
     occurred_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     INDEX idx_outbox_aggregate (aggregate_type, aggregate_id),


### PR DESCRIPTION
## 개요

이슈 #26 - payment-service에 남아 있던 OpenTelemetry / Tempo 분산 트레이싱 흔적을 의존성, 설정, 코드, DB 스키마에서 모두 제거합니다.

## 변경 파일

- `build.gradle`
  - `io.micrometer:micrometer-tracing-bridge-otel` 의존성 제거
  - `io.opentelemetry:opentelemetry-exporter-otlp` 의존성 제거
- `PaymentServiceApplication.java`
  - `Hooks.enableAutomaticContextPropagation()` 호출 및 관련 주석 제거
- `application.yml`
  - `management.tracing` 블록 제거
  - `management.otlp.tracing` 블록 제거
  - `logging.pattern.level`에서 `%X{traceId:-},%X{spanId:-}` 제거
- `OutboxEvent.java`
  - `traceId` 필드와 `@Column("trace_id")` 제거
- `OutboxService.java`
  - `Tracer` 의존성(`ObjectProvider<Tracer>`) 제거
  - `currentTraceId()` 메서드 제거
  - 빌더의 `.traceId(traceId)` 호출 제거
  - 로그 포맷의 `traceId={}` placeholder와 인자 제거
- `schema.sql`
  - `outbox_events.trace_id` 컬럼 제거

## 영향

- 트레이싱 정보가 더 이상 수집되거나 저장되지 않습니다.
- `outbox_events` 테이블 스키마가 변경되므로 기존 DB는 폐기 후 재생성합니다 (운영 데이터 아님).
- 관측성은 Prometheus(metrics)와 Loki(logs) 조합으로 단순화됩니다.

## 검증

- [ ] `./gradlew compileJava` 통과
- [ ] mariadb payment DB 재생성 (PVC 삭제 + StatefulSet 재기동)
- [ ] 파드 정상 기동 및 outbox 발행 정상 확인

Closes #26