### PR TITLE
fix: 결제 완료/환불 outbox 이벤트 연결

### DIFF
--- a/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
+++ b/src/main/java/com/opentraum/payment/domain/service/PaymentService.java
@@ -6,6 +6,7 @@ import com.opentraum.payment.domain.dto.PaymentInitResponse;
 import com.opentraum.payment.domain.dto.WebhookRequest;
 import com.opentraum.payment.domain.entity.Payment;
 import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.domain.outbox.service.OutboxService;
 import com.opentraum.payment.domain.repository.PaymentRepository;
 import com.opentraum.payment.domain.repository.PaymentQueryRepository;
 import com.opentraum.payment.global.exception.BusinessException;
@@ -15,12 +16,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,12 +31,20 @@ import java.util.UUID;
 @Service
 public class PaymentService {
 
+    private static final String AGGREGATE_TYPE = "payment";
+    private static final String EVENT_PAYMENT_COMPLETED = "PaymentCompleted";
+    private static final String EVENT_PAYMENT_FAILED = "PaymentFailed";
+    private static final String EVENT_REFUND_COMPLETED = "RefundCompleted";
+    private static final String EVENT_REFUND_FAILED = "RefundFailed";
+
     private final PaymentRepository paymentRepository;
     private final PaymentQueryRepository paymentQueryRepository;
     private final PortOneClient portOneClient;
     private final PaymentTimerService timerService;
     private final WebClient reservationWebClient;
     private final WebClient eventWebClient;
+    private final OutboxService outboxService;
+    private final TransactionalOperator transactionalOperator;
     private final long paymentDelayMs;
 
     public PaymentService(PaymentRepository paymentRepository,
@@ -42,6 +53,8 @@ public class PaymentService {
                           PaymentTimerService timerService,
                           @Qualifier("reservationWebClient") WebClient reservationWebClient,
                           @Qualifier("eventWebClient") WebClient eventWebClient,
+                          OutboxService outboxService,
+                          TransactionalOperator transactionalOperator,
                           @Value("${opentraum.payment.delay-ms:2000}") long paymentDelayMs) {
         this.paymentRepository = paymentRepository;
         this.paymentQueryRepository = paymentQueryRepository;
@@ -49,6 +62,8 @@ public class PaymentService {
         this.timerService = timerService;
         this.reservationWebClient = reservationWebClient;
         this.eventWebClient = eventWebClient;
+        this.outboxService = outboxService;
+        this.transactionalOperator = transactionalOperator;
         this.paymentDelayMs = paymentDelayMs;
     }
 
@@ -137,28 +152,40 @@ public class PaymentService {
     public Mono<Payment> completePayment(WebhookRequest request) {
         return paymentRepository.findByMerchantUid(request.getMerchantUid())
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
-                // 1. 이미 완료된 결제 중복 처리 방지
                 .flatMap(payment -> {
                     if (PaymentStatus.COMPLETED.name().equals(payment.getStatus())) {
                         return Mono.error(new BusinessException(ErrorCode.PAYMENT_ALREADY_COMPLETED));
                     }
-                    return Mono.just(payment);
+                    return portOneClient.verifyPayment(request.getMerchantUid(), payment.getAmount())
+                            .doOnError(err -> log.warn("결제 검증 API 호출 실패: merchantUid={}, err={}",
+                                    request.getMerchantUid(), err.getMessage()))
+                            .flatMap(verification -> {
+                                if (!payment.getAmount().equals(verification.getAmount())) {
+                                    log.error("결제 금액 불일치: expected={}, actual={}",
+                                            payment.getAmount(), verification.getAmount());
+                                    BusinessException error = new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+                                    return persistFailedWithOutbox(payment, "PAYMENT_AMOUNT_MISMATCH")
+                                            .then(Mono.<Payment>error(error));
+                                }
+                                if (PaymentStatus.FAILED.equals(verification.getStatus())) {
+                                    BusinessException error = new BusinessException(
+                                            ErrorCode.PAYMENT_AMOUNT_MISMATCH,
+                                            "PortOne 결제 상태가 실패입니다.");
+                                    return persistFailedWithOutbox(payment, "PORTONE_PAYMENT_FAILED")
+                                            .then(Mono.<Payment>error(error));
+                                }
+                                if (!PaymentStatus.COMPLETED.equals(verification.getStatus())) {
+                                    return Mono.error(new BusinessException(
+                                            ErrorCode.INTERNAL_ERROR,
+                                            "PortOne 결제가 아직 완료되지 않았습니다."));
+                                }
+                                payment.setImpUid(request.getImpUid());
+                                payment.setStatus(PaymentStatus.COMPLETED.name());
+                                payment.setPaidAt(LocalDateTime.now());
+                                payment.setUpdatedAt(LocalDateTime.now());
+                                return persistCompletedWithOutbox(payment);
+                            });
                 })
-                // 2. PG사 금액 검증 (V2: merchantUid = PortOne paymentId)
-                .flatMap(payment -> portOneClient.verifyPayment(request.getMerchantUid(), payment.getAmount())
-                        .flatMap(verification -> {
-                            if (!payment.getAmount().equals(verification.getAmount())) {
-                                log.error("결제 금액 불일치: expected={}, actual={}",
-                                        payment.getAmount(), verification.getAmount());
-                                return Mono.error(new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
-                            }
-                            payment.setImpUid(request.getImpUid());
-                            payment.setStatus(PaymentStatus.COMPLETED.name());
-                            payment.setPaidAt(LocalDateTime.now());
-                            payment.setUpdatedAt(LocalDateTime.now());
-                            return paymentRepository.save(payment);
-                        }))
-                // 3. 타이머 취소
                 .flatMap(payment -> timerService.cancelPaymentTimer(payment.getReservationId())
                         .thenReturn(payment))
                 .doOnSuccess(payment -> log.info("결제 완료: paymentId={}, merchantUid={}",
@@ -169,18 +196,31 @@ public class PaymentService {
     public Mono<PortOneClient.RefundResult> refundPayment(Long paymentId, String reason) {
         return paymentRepository.findById(paymentId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
-                .flatMap(payment -> portOneClient.cancelPayment(
-                        payment.getMerchantUid(),
-                        payment.getAmount(),
-                        reason
-                ).flatMap(result -> {
-                    if (result.isSuccess()) {
-                        payment.setStatus(PaymentStatus.REFUNDED.name());
-                        payment.setUpdatedAt(LocalDateTime.now());
-                        return paymentRepository.save(payment).thenReturn(result);
+                .flatMap(payment -> {
+                    if (PaymentStatus.REFUNDED.name().equals(payment.getStatus())) {
+                        return Mono.just(PortOneClient.RefundResult.builder()
+                                .success(true)
+                                .message("ALREADY_REFUNDED")
+                                .build());
                     }
-                    return Mono.just(result);
-                }));
+                    return portOneClient.cancelPayment(
+                                    payment.getMerchantUid(),
+                                    payment.getAmount(),
+                                    reason
+                            )
+                            .flatMap(result -> {
+                                if (result.isSuccess()) {
+                                    payment.setStatus(PaymentStatus.REFUNDED.name());
+                                    payment.setUpdatedAt(LocalDateTime.now());
+                                    return persistRefundCompletedWithOutbox(payment, reason)
+                                            .thenReturn(result);
+                                }
+                                return publishRefundFailed(payment, result.getMessage())
+                                        .thenReturn(result);
+                            })
+                            .onErrorResume(err -> publishRefundFailed(payment, err.getMessage())
+                                    .then(Mono.<PortOneClient.RefundResult>error(err)));
+                });
     }
 
     // 결제 단건 조회
@@ -203,5 +243,78 @@ public class PaymentService {
     private String generateMerchantUid() {
         return "OT_" + System.currentTimeMillis() + "_" +
                 UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private Mono<Payment> persistCompletedWithOutbox(Payment payment) {
+        String sagaId = UUID.randomUUID().toString();
+        Mono<Payment> tx = paymentRepository.save(payment)
+                .flatMap(saved -> {
+                    Map<String, Object> payload = new LinkedHashMap<>();
+                    payload.put("payment_id", saved.getId());
+                    payload.put("amount", saved.getAmount());
+                    return outboxService.publish(
+                                    saved.getReservationId(),
+                                    AGGREGATE_TYPE,
+                                    EVENT_PAYMENT_COMPLETED,
+                                    sagaId,
+                                    payload)
+                            .thenReturn(saved);
+                });
+        return transactionalOperator.transactional(tx);
+    }
+
+    private Mono<Payment> persistFailedWithOutbox(Payment payment, String reason) {
+        String sagaId = UUID.randomUUID().toString();
+        payment.setStatus(PaymentStatus.FAILED.name());
+        payment.setUpdatedAt(LocalDateTime.now());
+        Mono<Payment> tx = paymentRepository.save(payment)
+                .flatMap(saved -> {
+                    Map<String, Object> payload = new LinkedHashMap<>();
+                    payload.put("payment_id", saved.getId());
+                    payload.put("amount", saved.getAmount());
+                    payload.put("reason", reason == null ? "PAYMENT_FAILED" : reason);
+                    return outboxService.publish(
+                                    saved.getReservationId(),
+                                    AGGREGATE_TYPE,
+                                    EVENT_PAYMENT_FAILED,
+                                    sagaId,
+                                    payload)
+                            .thenReturn(saved);
+                });
+        return transactionalOperator.transactional(tx);
+    }
+
+    private Mono<Payment> persistRefundCompletedWithOutbox(Payment payment, String reason) {
+        String sagaId = UUID.randomUUID().toString();
+        Mono<Payment> tx = paymentRepository.save(payment)
+                .flatMap(saved -> {
+                    Map<String, Object> payload = new LinkedHashMap<>();
+                    payload.put("payment_id", saved.getId());
+                    payload.put("amount", saved.getAmount());
+                    payload.put("reason", reason);
+                    return outboxService.publish(
+                                    saved.getReservationId(),
+                                    AGGREGATE_TYPE,
+                                    EVENT_REFUND_COMPLETED,
+                                    sagaId,
+                                    payload)
+                            .thenReturn(saved);
+                });
+        return transactionalOperator.transactional(tx);
+    }
+
+    private Mono<Void> publishRefundFailed(Payment payment, String reason) {
+        String sagaId = UUID.randomUUID().toString();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("payment_id", payment.getId());
+        payload.put("amount", payment.getAmount());
+        payload.put("reason", reason == null ? "REFUND_FAILED" : reason);
+        return outboxService.publish(
+                        payment.getReservationId(),
+                        AGGREGATE_TYPE,
+                        EVENT_REFUND_FAILED,
+                        sagaId,
+                        payload)
+                .then();
     }
 }

--- a/src/test/java/com/opentraum/payment/domain/service/PaymentServiceTest.java
+++ b/src/test/java/com/opentraum/payment/domain/service/PaymentServiceTest.java
@@ -1,0 +1,115 @@
+package com.opentraum.payment.domain.service;
+
+import com.opentraum.payment.domain.client.PortOneClient;
+import com.opentraum.payment.domain.dto.WebhookRequest;
+import com.opentraum.payment.domain.entity.Payment;
+import com.opentraum.payment.domain.entity.PaymentStatus;
+import com.opentraum.payment.domain.outbox.service.OutboxService;
+import com.opentraum.payment.domain.repository.PaymentQueryRepository;
+import com.opentraum.payment.domain.repository.PaymentRepository;
+import com.opentraum.payment.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PaymentServiceTest {
+
+    private final PaymentRepository paymentRepository = mock(PaymentRepository.class);
+    private final PaymentQueryRepository paymentQueryRepository = mock(PaymentQueryRepository.class);
+    private final PortOneClient portOneClient = mock(PortOneClient.class);
+    private final PaymentTimerService timerService = mock(PaymentTimerService.class);
+    private final WebClient reservationWebClient = mock(WebClient.class);
+    private final WebClient eventWebClient = mock(WebClient.class);
+    private final OutboxService outboxService = mock(OutboxService.class);
+    private final TransactionalOperator transactionalOperator = mock(TransactionalOperator.class);
+
+    private PaymentService service;
+
+    @BeforeEach
+    void setUp() {
+        when(transactionalOperator.transactional(any(Mono.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        service = new PaymentService(
+                paymentRepository,
+                paymentQueryRepository,
+                portOneClient,
+                timerService,
+                reservationWebClient,
+                eventWebClient,
+                outboxService,
+                transactionalOperator,
+                0L);
+    }
+
+    @Test
+    void completePaymentDoesNotPublishFailureWhenVerificationCallFails() {
+        Payment payment = pendingPayment();
+        RuntimeException timeout = new RuntimeException("portone-timeout");
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Mono.just(payment));
+        when(portOneClient.verifyPayment("merchant-1", 1000)).thenReturn(Mono.error(timeout));
+
+        StepVerifier.create(service.completePayment(webhook("merchant-1")))
+                .expectErrorMatches(error -> error == timeout)
+                .verify();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING.name());
+        verify(paymentRepository, never()).save(any(Payment.class));
+        verify(outboxService, never()).publish(anyLong(), anyString(), eq("PaymentFailed"), anyString(), anyMap());
+        verify(timerService, never()).cancelPaymentTimer(anyLong());
+    }
+
+    @Test
+    void completePaymentPublishesFailureOnlyForVerifiedPaymentMismatch() {
+        Payment payment = pendingPayment();
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Mono.just(payment));
+        when(portOneClient.verifyPayment("merchant-1", 1000)).thenReturn(Mono.just(
+                PortOneClient.PaymentVerificationResult.builder()
+                        .paymentId("merchant-1")
+                        .amount(900)
+                        .status(PaymentStatus.COMPLETED)
+                        .build()));
+        when(paymentRepository.save(payment)).thenReturn(Mono.just(payment));
+        when(outboxService.publish(anyLong(), anyString(), eq("PaymentFailed"), anyString(), anyMap()))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(service.completePayment(webhook("merchant-1")))
+                .expectError(BusinessException.class)
+                .verify();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED.name());
+        verify(paymentRepository).save(payment);
+        verify(outboxService).publish(eq(10L), eq("payment"), eq("PaymentFailed"), anyString(), anyMap());
+        verify(timerService, never()).cancelPaymentTimer(anyLong());
+    }
+
+    private static Payment pendingPayment() {
+        return Payment.builder()
+                .id(1L)
+                .reservationId(10L)
+                .merchantUid("merchant-1")
+                .amount(1000)
+                .status(PaymentStatus.PENDING.name())
+                .build();
+    }
+
+    private static WebhookRequest webhook(String merchantUid) {
+        WebhookRequest request = new WebhookRequest();
+        request.setMerchantUid(merchantUid);
+        request.setImpUid("imp-1");
+        return request;
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 결제 완료 직접 경로에서 `PaymentCompleted` outbox 이벤트를 결제 저장과 같은 reactive transaction 안에서 발행합니다.
- 결제 금액 불일치 또는 PG사 확정 실패 상태일 때만 `PaymentFailed` outbox 이벤트를 저장합니다.
- PortOne 검증 API 호출 자체가 실패한 경우에는 결제 상태를 실패로 오염시키지 않고 원 오류를 전파합니다.
- 환불 성공/실패 경로에 `RefundCompleted`, `RefundFailed` outbox 이벤트를 연결합니다.
- 결제 검증 실패와 금액 불일치 분기를 회귀 테스트로 고정했습니다.

## 배경 / 원인

결제 직접 완료/환불 경로가 CDC outbox 흐름과 완전히 연결되지 않으면 reservation-service가 결제 완료/환불 이벤트를 안정적으로 소비하지 못합니다. 특히 PG 검증 API 네트워크 오류를 결제 실패로 저장하면 실제 결제가 완료되었을 가능성이 있는 상태를 로컬에서 실패로 확정하는 문제가 생깁니다.

## 팀 공유사항

- PortOne 검증 API 호출 실패는 `PaymentFailed` 이벤트를 만들지 않습니다. 이 케이스는 재시도 또는 운영 확인 대상입니다.
- `PaymentFailed`는 금액 불일치 또는 PG가 명확히 실패 상태를 반환한 경우에만 발행됩니다.
- `RefundFailed`는 결제 상태를 바꾸지 않고 outbox 이벤트만 발행합니다.
- 수동 K8s 배포 이미지 기준 E2E/API는 `74/74` 통과했지만, 이후 ArgoCD selfHeal 복구로 현재 클러스터 이미지는 GitOps 기준 이미지로 되돌아간 상태입니다. 이 PR이 merge되어야 같은 변경이 GitOps 배포에 반영됩니다.

## 검증

- `./gradlew test` 통과
- `./gradlew bootJar` 통과
- 수동 배포 이미지 기준 K8s E2E/API `74/74` 통과

## 영향 범위

- payment-service 결제 완료/환불 도메인 로직
- payment outbox 이벤트 발행
- reservation-service의 결제 이벤트 소비 경로에 간접 영향

## 관련 이슈

- Related: #25
