### PR TITLE
feat: #29 Harbor → ECR 마이그레이션

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,8 +7,14 @@ on:
 permissions:
   contents: write
 
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REGISTRY: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: skala3-cloud1-team8-opentraum-payment-service
+
 jobs:
   build_image:
+
     runs-on: ubuntu-latest
     steps:
       - name: 코드 체크아웃
@@ -17,18 +23,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: QEMU 설정
-        uses: docker/setup-qemu-action@v3
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Amazon ECR 로그인
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3
-
-      - name: Harbor 로그인
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.HARBOR_REGISTRY }}
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Docker 이미지 빌드 및 푸시
         uses: docker/build-push-action@v5
@@ -36,14 +42,18 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.HARBOR_REGISTRY }}/skala26a-cloud/opentraum-payment-service:${{ github.sha }}
+          platforms: linux/amd64
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   update_manifest:
+
     needs: build_image
     runs-on: ubuntu-latest
+    env:
+      ECR_REGISTRY: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com
+      ECR_REPOSITORY: skala3-cloud1-team8-opentraum-payment-service
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
@@ -58,7 +68,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/OpenTraum/OpenTraum-payment-service.git
           git fetch origin main
           git checkout main
-          sed -i "s|image: .*opentraum-payment-service.*|image: ${{ secrets.HARBOR_REGISTRY }}/skala26a-cloud/opentraum-payment-service:${{ github.sha }}|" k8s/deployment.yml
+          sed -i "s|image: .*opentraum-payment-service.*|image: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}|" k8s/deployment.yml
           git add k8s/deployment.yml
           if git diff --cached --quiet; then
             exit 0

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -23,8 +23,6 @@ spec:
         app.kubernetes.io/component: payment
     spec:
       terminationGracePeriodSeconds: 40
-      imagePullSecrets:
-        - name: harbor-secret
       priorityClassName: opentraum-high
       affinity:
         podAffinity:
@@ -60,7 +58,7 @@ spec:
               app.kubernetes.io/part-of: opentraum
       containers:
         - name: payment-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-payment-service:2c2e1577f1b17da2e582f98870cccbeb88f48eb4
+          image: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com/skala3-cloud1-team8-opentraum-payment-service:2c2e1577f1b17da2e582f98870cccbeb88f48eb4
           imagePullPolicy: Always
           ports:
             - containerPort: 8085


### PR DESCRIPTION
Closes #29

## 변경
- `.github/workflows/cicd.yml`: Harbor → ECR (skala3-cloud1-team8-opentraum-payment-service)
- `k8s/deployment.yml`: 이미지 URI ECR로 + imagePullSecrets 제거

## 머지 조건
- [ ] secrets `AWS_ACCESS_KEY_ID` 등록
- [ ] secrets `AWS_SECRET_ACCESS_KEY` 등록

## 인증 모델
노드 IAM에 `AmazonEC2ContainerRegistryPullOnly` 부착됨 → Pod imagePullSecrets 불필요