### PR TITLE
chore: #33 Pod 자원 재산정

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -92,8 +92,8 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "200m"
             limits:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "200m"
       restartPolicy: Always


### PR DESCRIPTION
Closes #33

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `500m` → `200m`
- `resources.requests.memory`: `512Mi` 유지
- `resources.limits.cpu`: `500m` → `200m`
- `resources.limits.memory`: `512Mi` 유지

## 영향
- QoS: `Guaranteed` 유지
- CPU request 절감: -300m
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 1개 교체 (`maxSurge: 1`, `maxUnavailable: 0`)
